### PR TITLE
Free the memory leaks from rbus gtest - Session & msg

### DIFF
--- a/src/core/rbuscore_message.c
+++ b/src/core/rbuscore_message.c
@@ -71,6 +71,8 @@
     }\
     return RT_OK;
 
+#define VERIFY_NULL(T)          if(NULL == T){ RBUSCORELOG_WARN(#T" is NULL"); return; }
+
 struct _rbusMessage
 {
     rtRetainable retainable;
@@ -109,6 +111,7 @@ void rbusMessage_Retain(rbusMessage message)
 
 void rbusMessage_Release(rbusMessage message)
 {
+    VERIFY_NULL(message);
     rtRetainable_release(message, rbusMessage_Destroy);
 }
 

--- a/src/core/rbuscore_message.c
+++ b/src/core/rbuscore_message.c
@@ -71,7 +71,6 @@
     }\
     return RT_OK;
 
-#define VERIFY_NULL(T)          if(NULL == T){ RBUSCORELOG_WARN(#T" is NULL"); return; }
 
 struct _rbusMessage
 {
@@ -111,8 +110,8 @@ void rbusMessage_Retain(rbusMessage message)
 
 void rbusMessage_Release(rbusMessage message)
 {
-    VERIFY_NULL(message);
-    rtRetainable_release(message, rbusMessage_Destroy);
+    if(message)
+        rtRetainable_release(message, rbusMessage_Destroy);
 }
 
 void rbusMessage_FromBytes(rbusMessage* message, uint8_t const* buff, uint32_t n)

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4624,10 +4624,7 @@ rbusError_t rbus_createSession(rbusHandle_t handle, uint32_t *pSessionId)
             RBUSLOG_ERROR("Failed to communicated with session manager.");
             rc = rbusCoreError_to_rbusError(err);
         }
-	if (response != NULL)
-	{
-	    rbusMessage_Release(response);
-	}
+	rbusMessage_Release(response);
     }
     else
     {
@@ -4666,10 +4663,7 @@ rbusError_t rbus_getCurrentSession(rbusHandle_t handle, uint32_t *pSessionId)
             RBUSLOG_ERROR("Failed to communicated with session manager.");
             rc = rbusCoreError_to_rbusError(err);
         }
-	if (response != NULL)
-	{
-	    rbusMessage_Release(response);
-	}
+	rbusMessage_Release(response);
     }
     else
     {
@@ -4708,10 +4702,7 @@ rbusError_t rbus_closeSession(rbusHandle_t handle, uint32_t sessionId)
             RBUSLOG_ERROR("Failed to communicated with session manager.");
             rc = rbuscoreError_to_rbusError(err);
         }
-        if (response != NULL)
-        {
-            rbusMessage_Release(response);
-        }
+        rbusMessage_Release(response);
     }
     else
     {

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2334,9 +2334,6 @@ exit_error1:
 
 exit_error0:
 
-    if(handle)
-        *handle = NULL;
-
     if(ret == RBUS_ERROR_SUCCESS)
         ret = RBUS_ERROR_BUS_ERROR;
 
@@ -4604,7 +4601,7 @@ rbusError_t rbus_createSession(rbusHandle_t handle, uint32_t *pSessionId)
     (void)handle;
     rbusError_t rc = RBUS_ERROR_SUCCESS;
     rbusCoreError_t err = RBUSCORE_SUCCESS;
-    rbusMessage response;
+    rbusMessage response  = NULL;
     if (pSessionId && handle)
     {
         *pSessionId = 0;
@@ -4627,6 +4624,10 @@ rbusError_t rbus_createSession(rbusHandle_t handle, uint32_t *pSessionId)
             RBUSLOG_ERROR("Failed to communicated with session manager.");
             rc = rbusCoreError_to_rbusError(err);
         }
+	if (response != NULL)
+	{
+	    rbusMessage_Release(response);
+	}
     }
     else
     {
@@ -4641,7 +4642,7 @@ rbusError_t rbus_getCurrentSession(rbusHandle_t handle, uint32_t *pSessionId)
     (void)handle;
     rbusError_t rc = RBUS_ERROR_SUCCESS;
     rbusCoreError_t err = RBUSCORE_SUCCESS;
-    rbusMessage response;
+    rbusMessage response = NULL;
 
     if (pSessionId && handle)
     {
@@ -4665,6 +4666,10 @@ rbusError_t rbus_getCurrentSession(rbusHandle_t handle, uint32_t *pSessionId)
             RBUSLOG_ERROR("Failed to communicated with session manager.");
             rc = rbusCoreError_to_rbusError(err);
         }
+	if (response != NULL)
+	{
+	    rbusMessage_Release(response);
+	}
     }
     else
     {
@@ -4683,7 +4688,7 @@ rbusError_t rbus_closeSession(rbusHandle_t handle, uint32_t sessionId)
     if ((0 != sessionId) && (handle))
     {
         rbusMessage inputSession;
-        rbusMessage response;
+        rbusMessage response = NULL;
 
         rbusMessage_Init(&inputSession);
         rbusMessage_SetInt32(inputSession, /*MESSAGE_FIELD_PAYLOAD,*/ sessionId);
@@ -4701,7 +4706,11 @@ rbusError_t rbus_closeSession(rbusHandle_t handle, uint32_t sessionId)
         else
         {
             RBUSLOG_ERROR("Failed to communicated with session manager.");
-            rc = rbusCoreError_to_rbusError(err);
+            rc = rbuscoreError_to_rbusError(err);
+        }
+        if (response != NULL)
+        {
+            rbusMessage_Release(response);
         }
     }
     else

--- a/unittests/rbus/rbusApiNegTest.cpp
+++ b/unittests/rbus/rbusApiNegTest.cpp
@@ -413,6 +413,7 @@ TEST(rbusSetMultiNegTest, test3)
     rc = rbus_setMulti(handle, 1, next, NULL);
     EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
     rbusProperty_Release(next);
+    rbusValue_Release(setVal1);
 }
 
 TEST(rbusSetIntNegTest, test1)
@@ -897,10 +898,9 @@ TEST(rbusSessionNegTest, test6)
 TEST(rbusInvokeNegTest, test1)
 {
     int rc = RBUS_ERROR_BUS_ERROR;
-    rbusHandle_t handle = NULL;
+    rbusHandle_t handle;
     rbusObject_t inParams = NULL, outParams = NULL;
     const char *componentName = "rbusApi";
-    handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
 
     rc=rbus_open(&handle,componentName);
     EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
@@ -910,7 +910,8 @@ TEST(rbusInvokeNegTest, test1)
     EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
     if(outParams)
         rbusObject_Release(outParams);
-
+    if(inParams)
+       rbusObject_Release(inParams);
     rc=rbus_close(handle);
     EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
 }
@@ -926,16 +927,17 @@ TEST(rbusInvokeNegTest, test2)
     EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
     if(outParams)
         rbusObject_Release(outParams);
+    if(inParams)
+       rbusObject_Release(inParams);
 }
 
 TEST(rbusInvokeNegTest, test3)
 {
     int rc = RBUS_ERROR_BUS_ERROR;
-    rbusHandle_t handle = NULL;
+    rbusHandle_t handle;
     rbusObject_t inParams = NULL, outParams = NULL;
     const char *method = "Device.rbusProvider.Method123()";
     const char *componentName = "rbusApi";
-    handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
 
     rc=rbus_open(&handle,componentName);
     EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
@@ -945,6 +947,10 @@ TEST(rbusInvokeNegTest, test3)
     EXPECT_EQ(rc, RBUS_ERROR_DESTINATION_NOT_REACHABLE);
     if(outParams)
         rbusObject_Release(outParams);
+    if(inParams)
+       rbusObject_Release(inParams);
+    rc=rbus_close(handle);
+    EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
 }
 
 TEST(rbusInvokeAsyncNegTest, test1)

--- a/unittests/rbus/rbusSessionTest.cpp
+++ b/unittests/rbus/rbusSessionTest.cpp
@@ -44,6 +44,7 @@ TEST(rbusSessionTest, test1)
 
     rc = rbus_closeSession(handle, sessionId);
     EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
+    rbus_close(handle);
   }
   free(componentName);
 }


### PR DESCRIPTION
    Reason for change: Fixed memory leaks in session manager code
    Test Procedure: Build and test rbus, run valgrind
    Risks: Low
    Priority: P2