### PR TITLE
RDKB-44513 - Free the memory leaks from rbus gtest

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2686,8 +2686,7 @@ rbusError_t rbus_get(rbusHandle_t handle, char const* name, rbusValue_t* value)
                 errorcode = CCSPError_to_rbusError(legacyRetCode);
             }
         }
-        if(response != NULL)//check if "response" is already Freed And Set to Null in rbus_invokeRemoteMethod()
-            rbusMessage_Release(response);
+        rbusMessage_Release(response);
     }
     return errorcode;
 }

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2689,8 +2689,8 @@ rbusError_t rbus_get(rbusHandle_t handle, char const* name, rbusValue_t* value)
                 errorcode = CCSPError_to_rbusError(legacyRetCode);
             }
         }
-
-        rbusMessage_Release(response);
+        if(response != NULL)//check if "response" is already Freed And Set to Null in rbus_invokeRemoteMethod()
+            rbusMessage_Release(response);
     }
     return errorcode;
 }

--- a/src/rbus/rbus_element.c
+++ b/src/rbus/rbus_element.c
@@ -237,11 +237,11 @@ elementNode* insertElement(elementNode* root, rbusDataElement_t* elem)
        mutex_init = 1;
     }
 
-    LOCK();
     if(currentNode == NULL || elem == NULL)
     {
         return NULL;
     }
+    LOCK();
     nextNode = currentNode->child;
     createChild = 1;
 

--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -1231,13 +1231,6 @@ rtConnection_SendInternal(rtConnection con, uint8_t const* buff, uint32_t n, cha
     return err;
   }
 
-if(message ==NULL)
-{
-rtLog_Warn("**$$$$$$___Deepak  %s:%d  ***message:%s**  ERR:%d",__FUNCTION__,__LINE__,message, err);
-   return err;
-
-}
-rtLog_Warn("**$$$$$$___Deepak 2 %s:%d  ***message:%s**  ERR:%d",__FUNCTION__,__LINE__,message, err);
   struct iovec send_vec[] = {{con->send_buffer, header.header_length}, {(void *)message, header.payload_length}};
   struct msghdr send_hdr = {NULL, 0, send_vec, 2, NULL, 0, 0};
 

--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -1146,7 +1146,7 @@ rtConnection_SendInternal(rtConnection con, uint8_t const* buff, uint32_t n, cha
   int max_attempts;
   ssize_t bytes_sent;
   rtMessageHeader header;
-  uint8_t const* message;
+  uint8_t const* message =NULL;
   uint32_t message_length;
 
   if (!con)
@@ -1179,7 +1179,7 @@ rtConnection_SendInternal(rtConnection con, uint8_t const* buff, uint32_t n, cha
     message_length = n;
   }
 
-  max_attempts = 2;
+  max_attempts = 3;
   num_attempts = 0;
 
   rtMessageHeader_Init(&header);
@@ -1231,11 +1231,19 @@ rtConnection_SendInternal(rtConnection con, uint8_t const* buff, uint32_t n, cha
     return err;
   }
 
+if(message ==NULL)
+{
+rtLog_Warn("**$$$$$$___Deepak  %s:%d  ***message:%s**  ERR:%d",__FUNCTION__,__LINE__,message, err);
+   return err;
+
+}
+rtLog_Warn("**$$$$$$___Deepak 2 %s:%d  ***message:%s**  ERR:%d",__FUNCTION__,__LINE__,message, err);
   struct iovec send_vec[] = {{con->send_buffer, header.header_length}, {(void *)message, header.payload_length}};
   struct msghdr send_hdr = {NULL, 0, send_vec, 2, NULL, 0, 0};
 
   do
   {
+    err = RT_OK;
     bytes_sent = sendmsg(con->fd, &send_hdr, MSG_NOSIGNAL);
     if (bytes_sent != (ssize_t)(header.header_length + header.payload_length))
     {

--- a/unittests/rbus/rbusApiNegTest.cpp
+++ b/unittests/rbus/rbusApiNegTest.cpp
@@ -409,7 +409,6 @@ TEST(rbusSetMultiNegTest, test3)
     rbusValue_Init(&setVal1);
     rbusValue_SetFromString(setVal1, RBUS_STRING, "Gtest_set_multi_1");
     rbusProperty_Init(&next, NULL, setVal1);
-    rbusValue_Release(setVal1);
 
     rc = rbus_setMulti(handle, 1, next, NULL);
     EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);

--- a/unittests/rbus/rbusApiNegTest.cpp
+++ b/unittests/rbus/rbusApiNegTest.cpp
@@ -409,6 +409,7 @@ TEST(rbusSetMultiNegTest, test3)
     rbusValue_Init(&setVal1);
     rbusValue_SetFromString(setVal1, RBUS_STRING, "Gtest_set_multi_1");
     rbusProperty_Init(&next, NULL, setVal1);
+    rbusValue_Release(setVal1);
 
     rc = rbus_setMulti(handle, 1, next, NULL);
     EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);

--- a/unittests/rbus/rbusElementTest.cpp
+++ b/unittests/rbus/rbusElementTest.cpp
@@ -83,6 +83,7 @@ static void printRow(elementNode* root)
         fprintRegisteredElements(fp, root, 0);
         fflush(fp);
         fclose(fp);
+        free(buffer);
     }
 }
 

--- a/unittests/rbus/rbusObjectTest.cpp
+++ b/unittests/rbus/rbusObjectTest.cpp
@@ -309,6 +309,7 @@ TEST(rbusObjectTest, testFwrite)
 
   rbusObject_Init (&obj_ch, "ch_gTestObject");
   rbusObject_SetProperty(obj_ch, prop_ch);
+  rbusProperty_Release(prop_ch);
 
   rbusValue_Init(&val);
   EXPECT_EQ(rbusValue_SetFromString(val,RBUS_STRING,"ptr_string"),true);
@@ -336,5 +337,6 @@ TEST(rbusObjectTest, testFwrite)
   EXPECT_NE(strstr(stream_buf,"ptr_gTestProp"), nullptr);
   EXPECT_NE(strstr(stream_buf,"ch_gTestObject"), nullptr);
   EXPECT_NE(strstr(stream_buf,"ptr_gTestObject"), nullptr);
+  free(stream_buf);
 }
 

--- a/unittests/rbus/rbusPropertyTest.cpp
+++ b/unittests/rbus/rbusPropertyTest.cpp
@@ -92,8 +92,8 @@ TEST(rbusPropertyTest, testGetValue)
 
 TEST(rbusPropertyTest, testGetNext)
 {
-  rbusValue_t value;
-  rbusProperty_t prop1;
+  rbusValue_t value=NULL;
+  rbusProperty_t prop1=NULL;
   rbusProperty_t prop2;
   rbusProperty_t prop3;
   char const* name;
@@ -117,9 +117,10 @@ TEST(rbusPropertyTest, testGetNext)
   rbusProperty_SetNext(prop2, prop3);
   rbusValue_Release(value);
 
-  while(prop1) {
-      value = rbusProperty_GetValue(prop1);
-      rbus_val = rbusProperty_GetName(prop1);
+  rbusProperty_t next= prop1;
+  while(next) {
+      value = rbusProperty_GetValue(next);
+      rbus_val = rbusProperty_GetName(next);
       name = rbusValue_GetString(value, &len);
       if(strcmp(rbus_val,"Device.rbusPropertyTest1") == 0) {
 	  EXPECT_STREQ("test1", name) << "rbusProperty_GetNext failed testGetNext";
@@ -128,7 +129,7 @@ TEST(rbusPropertyTest, testGetNext)
       } else if(strcmp(rbus_val,"Device.rbusPropertyTest3") == 0) {
 	  EXPECT_STREQ("test3", name) << "rbusProperty_GetNext failed testGetNext";
       }
-      prop1 = rbusProperty_GetNext(prop1);
+      next = rbusProperty_GetNext(next);
   }
 
   rbusProperty_Release(prop1);
@@ -163,9 +164,11 @@ TEST(rbusPropertyTest, testPushBack)
   rbusProperty_Append(prop2, prop3);
   rbusValue_Release(value);
 
-  while(prop1) {
-      value = rbusProperty_GetValue(prop1);
-      rbus_val = rbusProperty_GetName(prop1);
+
+  rbusProperty_t next= prop1;
+  while(next) {
+      value = rbusProperty_GetValue(next);
+      rbus_val = rbusProperty_GetName(next);
       name = rbusValue_GetString(value, &len);
       if(strcmp(rbus_val,"Device.rbusPropertyTest1") == 0) {
 	  EXPECT_STREQ("test1", name) << "rbusProperty_Append failed testPushBack";
@@ -174,7 +177,7 @@ TEST(rbusPropertyTest, testPushBack)
       } else if(strcmp(rbus_val,"Device.rbusPropertyTest3") == 0) {
 	  EXPECT_STREQ("test3", name) << "rbusProperty_Append failed testPushBack";
       }
-      prop1 = rbusProperty_GetNext(prop1);
+      next = rbusProperty_GetNext(next);
   }
 
   rbusProperty_Release(prop1);
@@ -248,4 +251,5 @@ TEST(rbusPropertyTest, testFwrite)
   pRet = strstr(stream_buf,"value:");
   pRet += strlen("value:");
   EXPECT_EQ(strncmp(pRet,"test1",strlen("test1")),0);
+  free(stream_buf);
 }

--- a/unittests/rbus/rbusProvider.cpp
+++ b/unittests/rbus/rbusProvider.cpp
@@ -94,10 +94,12 @@ rbusError_t getVCHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHa
     rbusObject_t obj = NULL;
     rbusObject_Init(&obj, name);
     rbusValue_SetObject(value, obj);
+    rbusObject_Release(obj);
   } else if(strcmp("Device.rbusProvider.Property",name) == 0) {
     rbusProperty_t prop = NULL;
     rbusProperty_Init(&prop, name, NULL);
     rbusValue_SetProperty(value, prop);
+    rbusProperty_Release(prop);
   }
   else if(strcmp("Device.rbusProvider.Int16",name) == 0)
     rbusValue_SetInt16(value, GTEST_VAL_INT16);

--- a/unittests/rbus/rbusProvider.cpp
+++ b/unittests/rbus/rbusProvider.cpp
@@ -85,7 +85,7 @@ rbusError_t getVCHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHa
 
     rbusValue_SetInt32(value, mydata);
   } else if(strcmp("Device.rbusProvider.DateTime",name) == 0) {
-    rbusDateTime_t timeVal;
+    rbusDateTime_t timeVal={NULL,NULL};
     struct tm compileTime;
     getCompileTime(&compileTime);
     memcpy(&(timeVal.m_time), &compileTime, sizeof(struct tm));

--- a/unittests/rbus/rbusProvider.cpp
+++ b/unittests/rbus/rbusProvider.cpp
@@ -85,7 +85,8 @@ rbusError_t getVCHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHa
 
     rbusValue_SetInt32(value, mydata);
   } else if(strcmp("Device.rbusProvider.DateTime",name) == 0) {
-    rbusDateTime_t timeVal={NULL,NULL};
+    rbusDateTime_t timeVal;
+    memset(&timeVal,0,sizeof(timeVal));
     struct tm compileTime;
     getCompileTime(&compileTime);
     memcpy(&(timeVal.m_time), &compileTime, sizeof(struct tm));

--- a/unittests/rbus/rbusValueTest.cpp
+++ b/unittests/rbus/rbusValueTest.cpp
@@ -152,6 +152,7 @@ static void exec_validate_test(rbusValueType_t type,char *buffer)
       EXPECT_EQ(strncmp(pRet,buffer,len-1),0);
     }
   }
+  free(stream_buf);
 }
 
 static void increment_val(char *buffer)


### PR DESCRIPTION
Reason for change: Gtest Suits listed in Jira RDKB-44513 Description were failing
Test Procedure: Build rtmessage, rbuscore and start rtrouted", Build Rbus Gtests with valgrind mentioned in Jira Description
Risks: Low
Priority: P2
Signed-off-by: Deepak <deepak_m@comcast.com>