### PR TITLE
Order of Table and its childs registraion in RBUS is addressed

### DIFF
--- a/src/rtmessage/rtRoutingTree.c
+++ b/src/rtmessage/rtRoutingTree.c
@@ -546,14 +546,7 @@ void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* r
 #endif
     }
 
-    /* Here, treeTopic should be the topic for the last token in workTokens list*/
-    
-    if(topic[strlen(topic)-1] == '.')
-    {
-        /* If its a partial path or a table send all routes listening to sub topics */
-        *routes = treeTopic->routeList2;
-    }
-    else if(treeTopic->isTable)
+    if(treeTopic->isTable)
     {
         /* If we ended on a table, then we need an additional check.
           We allow querying a table without adding the ".{i}" suffix.


### PR DESCRIPTION
 RDKB-44839: Order of Table and its childs registraion in RBUS is addressed 

  Reason for change: Facing Duplicate entry while a registering table with "Foo.SomeTable.{i}." format.
                     As per condition get routeList2 if the requested topic ends with "."and it is not matched with routeList2 topics.
  Solution: Removed condition check and returned route list instead of routeList2.
  Test Procedure: 1. Run test using rbusTestProvider, rbusTestConsumer
                  2. check Onewifi CSI feature broken issue.
  Risks: Low
  Signed-off-by: Netaji <NETAJI_PANIGRAHI@comcast.com>