### PR TITLE
Free the memory leaks definitely lost from rbus gtest

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3025,13 +3025,13 @@ static rbusError_t rbus_getByType(rbusHandle_t handle, char const* paramName, vo
                         break;
                 }
 
-                rbusValue_Release(value);
             }
             else
             {
                 RBUSLOG_ERROR("%s rbus_get type missmatch. expected %d. got %d", __FUNCTION__, type, rbusValue_GetType(value));
                 errorcode = RBUS_ERROR_BUS_ERROR;
             }
+            rbusValue_Release(value);
         }
     }
     return errorcode;

--- a/unittests/rbusConsumer.cpp
+++ b/unittests/rbusConsumer.cpp
@@ -50,11 +50,9 @@ static int exec_rbus_get_test(rbusHandle_t handle, const char *param)
 {
   int rc = RBUS_ERROR_BUS_ERROR;
   rbusValue_t val = NULL;
-  rbusValue_t retVal = NULL;
   rbusValueType_t type = RBUS_NONE;
 
   isElementPresent(handle, param);
-  retVal = rbusValue_Init(&val);
   rc = rbus_get(handle, param, &val);
   EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
 
@@ -120,7 +118,6 @@ static int exec_rbus_get_test(rbusHandle_t handle, const char *param)
 
 exit:
   rbusValue_Release(val);
-  rbusValue_Release(retVal);
 
   return rc;
 }

--- a/unittests/rbusConsumer.cpp
+++ b/unittests/rbusConsumer.cpp
@@ -50,10 +50,11 @@ static int exec_rbus_get_test(rbusHandle_t handle, const char *param)
 {
   int rc = RBUS_ERROR_BUS_ERROR;
   rbusValue_t val = NULL;
+  rbusValue_t retVal = NULL;
   rbusValueType_t type = RBUS_NONE;
 
   isElementPresent(handle, param);
-  rbusValue_Init(&val);
+  retVal = rbusValue_Init(&val);
   rc = rbus_get(handle, param, &val);
   EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
 
@@ -119,6 +120,7 @@ static int exec_rbus_get_test(rbusHandle_t handle, const char *param)
 
 exit:
   rbusValue_Release(val);
+  rbusValue_Release(retVal);
 
   return rc;
 }
@@ -626,7 +628,10 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
         rc = rbus_getStr(handle, param, &value);
 
         if(value)
+        {
           rc |= strcmp(value,"Device.rbusProvider.PartialPath.1.Param1");
+          free(value);
+        }
       }
       break;
     case RBUS_GTEST_GET26:


### PR DESCRIPTION
Reason for change: rectified incorrect initialization of structure rbusDateTime_t Test Procedure: Build rtmessage, rbuscore and start rtrouted", Build Rbus Gtests with valgrind mentioned in Jira Description Risks: Low
Priority: P2

Signed-off-by: Deepak <deepak_m@comcast.com>