### PR TITLE
RDKB-45363: RBUS Sample App (rbusMethodConsumer) crashing

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -56,7 +56,7 @@ static rbusOpenTelemetryContext* rbus_getOpenTelemetryContextFromThreadLocal();
 
 static void rbus_init_open_telemeetry_thread_specific_key()
 {
-  pthread_key_create(&_open_telemetry_key, NULL);
+  pthread_key_create(&_open_telemetry_key, free);
 }
 
 

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -524,8 +524,8 @@ void rbusObject_appendToMessage(rbusObject_t obj, rbusMessage msg)
 
 void rbusObject_initFromMessage(rbusObject_t* obj, rbusMessage msg)
 {
-    char const* name;
-    int type;
+    char const* name = NULL;
+    int type = 0;
     int numChild = 0;
     rbusProperty_t prop;
     rbusObject_t children=NULL, previous=NULL;


### PR DESCRIPTION
Reason for change: rbusMethodConsumer and rbusMethodProvider crashing Test Procedure: Run rbusMethodProvider and run rbusMethodConsumer with valgrind
Risks: Low

Signed-off-by: Deepthi <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>