### PR TITLE
RDKB-45280:Update the rtLog to support RDKLogger appropriately and modify rbus and rbuscore to use the rtLog Macro

### DIFF
--- a/src/core/rbuscore_logger.h
+++ b/src/core/rbuscore_logger.h
@@ -22,10 +22,10 @@
 #include <stdarg.h>
 #include "rtLog.h"
 
-#define RBUSCORELOG_ERROR(format, ...)       rtLog_ErrorFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_WARN(format, ...)        rtLog_WarnFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_INFO(format, ...)        rtLog_InfoFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_DEBUG(format, ...)       rtLog_DebugFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_TRACE(format, ...)       rtLog_DebugFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_ERROR(format, ...)       rtLog_ErrorPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_WARN(format, ...)        rtLog_WarnPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_INFO(format, ...)        rtLog_InfoPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_DEBUG(format, ...)       rtLog_DebugPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_TRACE(format, ...)       rtLog_DebugPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
 
 #endif  // __RBUS_CORE_LOG_H__

--- a/src/core/rbuscore_logger.h
+++ b/src/core/rbuscore_logger.h
@@ -20,26 +20,12 @@
 #define __RBUS_CORE_LOG_H__
 
 #include <stdarg.h>
-
-#ifdef ENABLE_RDKLOGGER
-#include "rdk_debug.h"
-
-
-#define RBUSCORELOG_ERROR(format, ...)       RDK_LOG(RDK_LOG_ERROR,  "LOG.RDK.RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_WARN(format, ...)        RDK_LOG(RDK_LOG_WARN,   "LOG.RDK.RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_INFO(format, ...)        RDK_LOG(RDK_LOG_INFO,   "LOG.RDK.RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_DEBUG(format, ...)       RDK_LOG(RDK_LOG_DEBUG,  "LOG.RDK.RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_TRACE(format, ...)       RDK_LOG(RDK_LOG_TRACE1, "LOG.RDK.RBUSCORE", format"\n", ##__VA_ARGS__)
-
-#else
 #include "rtLog.h"
 
-#define RBUSCORELOG_ERROR(format...)        rtLog_Error(format)
-#define RBUSCORELOG_WARN(format...)         rtLog_Warn(format)
-#define RBUSCORELOG_INFO(format...)         rtLog_Info(format)
-#define RBUSCORELOG_DEBUG(format...)        rtLog_Debug(format)
-#define RBUSCORELOG_TRACE(format...)        rtLog_Trace(format)
-
-#endif /* ENABLE_RDKLOGGER */
+#define RBUSCORELOG_ERROR(format, ...)       rtLog_ErrorFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_WARN(format, ...)        rtLog_WarnFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_INFO(format, ...)        rtLog_InfoFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_DEBUG(format, ...)       rtLog_DebugFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_TRACE(format, ...)       rtLog_DebugFmt("RBUSCORE", format"\n", ##__VA_ARGS__)
 
 #endif  // __RBUS_CORE_LOG_H__

--- a/src/rbus/rbus_log.h
+++ b/src/rbus/rbus_log.h
@@ -31,26 +31,13 @@
 #include <stdarg.h>
 #include "rtLog.h"
 
-#ifdef ENABLE_RDKLOGGER
-#include "rdk_debug.h"
+#define RBUSLOG_TRACE(format, ...)       rtLog_DebugFmt("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_DEBUG(format, ...)       rtLog_DebugFmt("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_INFO(format, ...)        rtLog_InfoFmt("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_WARN(format, ...)        rtLog_WarnFmt("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_ERROR(format, ...)       rtLog_ErrorFmt("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_FATAL(format, ...)       rtLog_FatalFmt("RBUS", format"\n", ##__VA_ARGS__)
 
-#define RBUSLOG_TRACE(format, ...)       RDK_LOG(RDK_LOG_TRACE1, "LOG.RDK.RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_DEBUG(format, ...)       RDK_LOG(RDK_LOG_DEBUG,  "LOG.RDK.RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_INFO(format, ...)        RDK_LOG(RDK_LOG_INFO,   "LOG.RDK.RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_WARN(format, ...)        RDK_LOG(RDK_LOG_WARN,   "LOG.RDK.RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_ERROR(format, ...)       RDK_LOG(RDK_LOG_ERROR,  "LOG.RDK.RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_FATAL(format, ...)       RDK_LOG(RDK_LOG_FATAL,  "LOG.RDK.RBUS", format"\n", ##__VA_ARGS__)
-
-#else
-
-#define RBUSLOG_TRACE rtLog_Debug
-#define RBUSLOG_DEBUG rtLog_Debug
-#define RBUSLOG_INFO rtLog_Info
-#define RBUSLOG_WARN rtLog_Warn
-#define RBUSLOG_ERROR rtLog_Error
-#define RBUSLOG_FATAL rtLog_Fatal
-
-#endif /* ENABLE_RDKLOGGER */
 #endif
 
 /** @} */

--- a/src/rbus/rbus_log.h
+++ b/src/rbus/rbus_log.h
@@ -31,12 +31,12 @@
 #include <stdarg.h>
 #include "rtLog.h"
 
-#define RBUSLOG_TRACE(format, ...)       rtLog_DebugFmt("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_DEBUG(format, ...)       rtLog_DebugFmt("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_INFO(format, ...)        rtLog_InfoFmt("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_WARN(format, ...)        rtLog_WarnFmt("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_ERROR(format, ...)       rtLog_ErrorFmt("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_FATAL(format, ...)       rtLog_FatalFmt("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_TRACE(format, ...)       rtLog_DebugPrint("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_DEBUG(format, ...)       rtLog_DebugPrint("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_INFO(format, ...)        rtLog_InfoPrint("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_WARN(format, ...)        rtLog_WarnPrint("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_ERROR(format, ...)       rtLog_ErrorPrint("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_FATAL(format, ...)       rtLog_FatalPrint("RBUS", format"\n", ##__VA_ARGS__)
 
 #endif
 

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -176,6 +176,7 @@ rtLoggerSelection rtLog_GetOption()
 }
 
 #define RT_LOG_BUFFER_SIZE    1024
+#define MODULE_BUFFER_SIZE    64
 void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, const char* format, ...)
 {
 
@@ -205,9 +206,9 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
     sLogHandler(level, path, line, threadId, buff);
   }
 #ifdef ENABLE_RDKLOGGER
-  else if (RT_USE_RDKLOGGER)
+  else if (sOption == RT_USE_RDKLOGGER)
   {
-    char module[RT_LOG_BUFFER_SIZE] = {0};
+    char module[MODULE_BUFFER_SIZE] = {0};
     sprintf(module, "LOG.RDK.%s", mod);
     RDK_LOG(level, module, buff);
   }

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -176,7 +176,7 @@ rtLoggerSelection rtLog_GetOption()
 }
 
 #define RT_LOG_BUFFER_SIZE    1024
-void rtLogPrintfFmt(rtLogLevel level, const char* mod, const char* file, int line, const char* format, ...)
+void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, const char* format, ...)
 {
 
   size_t n = 0;

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -223,9 +223,9 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
     gettimeofday(&tv, NULL);
     lt = localtime(&tv.tv_sec);
 
-    printf("%.2d:%.2d:%.2d.%.3lld %5s %s:%d -- [%s] -- Thread-%" RT_THREADID_FMT ": %s \n",
-        lt->tm_hour, lt->tm_min, lt->tm_sec, (long long int)tv.tv_usec,
-        rtLogLevelToString(level), path, line, mod, threadId, buff);
+    printf("%.2d:%.2d:%.2d.%.3lld  %-10s %5s %s:%d -- Thread-%" RT_THREADID_FMT ": %s",
+        lt->tm_hour, lt->tm_min, lt->tm_sec, (long long int)tv.tv_usec, mod,
+        rtLogLevelToString(level), path, line, threadId, buff);
   }
 }
 

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -176,7 +176,7 @@ rtLoggerSelection rtLog_GetOption()
 }
 
 #define RT_LOG_BUFFER_SIZE    1024
-void rtLogPrintf(rtLogLevel level, const char* file, int line, const char* format, ...)
+void rtLogPrintfFmt(rtLogLevel level, const char* mod, const char* file, int line, const char* format, ...)
 {
 
   size_t n = 0;
@@ -204,6 +204,14 @@ void rtLogPrintf(rtLogLevel level, const char* file, int line, const char* forma
   {
     sLogHandler(level, path, line, threadId, buff);
   }
+#ifdef ENABLE_RDKLOGGER
+  else if (RT_USE_RDKLOGGER)
+  {
+    char module[RT_LOG_BUFFER_SIZE] = {0};
+    sprintf(module, "LOG.RDK.%s", mod);
+    RDK_LOG(level, module, buff);
+  }
+#endif
   else
   {
     struct timeval tv;
@@ -214,9 +222,9 @@ void rtLogPrintf(rtLogLevel level, const char* file, int line, const char* forma
     gettimeofday(&tv, NULL);
     lt = localtime(&tv.tv_sec);
 
-    printf("%.2d:%.2d:%.2d.%.3lld %5s %s:%d -- Thread-%" RT_THREADID_FMT ": %s \n",
+    printf("%.2d:%.2d:%.2d.%.3lld %5s %s:%d -- [%s] -- Thread-%" RT_THREADID_FMT ": %s \n",
         lt->tm_hour, lt->tm_min, lt->tm_sec, (long long int)tv.tv_usec,
-        rtLogLevelToString(level), path, line, threadId, buff);
+        rtLogLevelToString(level), path, line, mod, threadId, buff);
   }
 }
 

--- a/src/rtmessage/rtLog.h
+++ b/src/rtmessage/rtLog.h
@@ -82,21 +82,19 @@ rtLoggerSelection rtLog_GetOption();
 #define RT_PRINTF_FORMAT(IDX, FIRST)
 #endif
 
-void rtLogPrintf(rtLogLevel level, const char* file, int line, const char* format, ...) RT_PRINTF_FORMAT(4, 5);
+void rtLogPrintfFmt (rtLogLevel level, const char* pModule, const char* file, int line, const char* format, ...) RT_PRINTF_FORMAT(5, 6);
 
-#ifdef ENABLE_RDKLOGGER
-#define rtLog_Debug(FORMAT,...)   do{if(rtLogGetLogHandler() || rtLog_GetOption() == RT_USE_RTLOGGER){rtLogPrintf(RT_LOG_DEBUG,__FILE__,__LINE__,FORMAT, ##__VA_ARGS__);}else{RDK_LOG(RDK_LOG_DEBUG,"LOG.RDK.RTMESSAGE",FORMAT"\n", ##__VA_ARGS__);}}while(0)
-#define rtLog_Info(FORMAT, ...)   do{if(rtLogGetLogHandler() || rtLog_GetOption() == RT_USE_RTLOGGER){rtLogPrintf(RT_LOG_INFO, __FILE__,__LINE__,FORMAT, ##__VA_ARGS__);}else{RDK_LOG(RDK_LOG_INFO, "LOG.RDK.RTMESSAGE",FORMAT"\n", ##__VA_ARGS__);}}while(0)
-#define rtLog_Warn(FORMAT, ...)   do{if(rtLogGetLogHandler() || rtLog_GetOption() == RT_USE_RTLOGGER){rtLogPrintf(RT_LOG_WARN, __FILE__,__LINE__,FORMAT, ##__VA_ARGS__);}else{RDK_LOG(RDK_LOG_WARN, "LOG.RDK.RTMESSAGE",FORMAT"\n", ##__VA_ARGS__);}}while(0)
-#define rtLog_Error(FORMAT, ...)  do{if(rtLogGetLogHandler() || rtLog_GetOption() == RT_USE_RTLOGGER){rtLogPrintf(RT_LOG_ERROR,__FILE__,__LINE__,FORMAT, ##__VA_ARGS__);}else{RDK_LOG(RDK_LOG_ERROR,"LOG.RDK.RTMESSAGE",FORMAT"\n", ##__VA_ARGS__);}}while(0)
-#define rtLog_Fatal(FORMAT, ...)  do{if(rtLogGetLogHandler() || rtLog_GetOption() == RT_USE_RTLOGGER){rtLogPrintf(RT_LOG_FATAL,__FILE__,__LINE__,FORMAT, ##__VA_ARGS__);}else{RDK_LOG(RDK_LOG_FATAL,"LOG.RDK.RTMESSAGE",FORMAT"\n", ##__VA_ARGS__);}}while(0)
-#else
-#define rtLog_Debug(FORMAT...) rtLogPrintf(RT_LOG_DEBUG, __FILE__, __LINE__, FORMAT)
-#define rtLog_Info(FORMAT...)  rtLogPrintf(RT_LOG_INFO,  __FILE__, __LINE__, FORMAT)
-#define rtLog_Warn(FORMAT...)  rtLogPrintf(RT_LOG_WARN,  __FILE__, __LINE__, FORMAT)
-#define rtLog_Error(FORMAT...) rtLogPrintf(RT_LOG_ERROR, __FILE__, __LINE__, FORMAT)
-#define rtLog_Fatal(FORMAT...) rtLogPrintf(RT_LOG_FATAL, __FILE__, __LINE__, FORMAT)
-#endif
+#define rtLog_DebugFmt(mod,FORMAT...)  rtLogPrintfFmt(RT_LOG_DEBUG, mod,__FILE__, __LINE__, FORMAT)
+#define rtLog_InfoFmt(mod,FORMAT...)   rtLogPrintfFmt(RT_LOG_INFO, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_WarnFmt(mod,FORMAT...)   rtLogPrintfFmt(RT_LOG_WARN, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_ErrorFmt(mod,FORMAT...)  rtLogPrintfFmt(RT_LOG_ERROR, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_FatalFmt(mod,FORMAT...)  rtLogPrintfFmt(RT_LOG_FATAL, mod, __FILE__, __LINE__, FORMAT)
+
+#define rtLog_Debug(FORMAT...) rtLog_DebugFmt("RTMESSAGE",FORMAT)
+#define rtLog_Info(FORMAT...)  rtLog_InfoFmt("RTMESSAGE",FORMAT)
+#define rtLog_Warn(FORMAT...)  rtLog_WarnFmt("RTMESSAGE",FORMAT)
+#define rtLog_Error(FORMAT...) rtLog_ErrorFmt("RTMESSAGE",FORMAT)
+#define rtLog_Fatal(FORMAT...) rtLog_FatalFmt("RTMESSAGE",FORMAT)
 
 #ifdef __cplusplus
 }

--- a/src/rtmessage/rtLog.h
+++ b/src/rtmessage/rtLog.h
@@ -90,11 +90,11 @@ void rtLogPrintf(rtLogLevel level, const char* pModule, const char* file, int li
 #define rtLog_ErrorPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_ERROR, mod, __FILE__, __LINE__, FORMAT)
 #define rtLog_FatalPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_FATAL, mod, __FILE__, __LINE__, FORMAT)
 
-#define rtLog_Debug(FORMAT...) rtLog_DebugPrint("RTMESSAGE",FORMAT)
-#define rtLog_Info(FORMAT...)  rtLog_InfoPrint("RTMESSAGE",FORMAT)
-#define rtLog_Warn(FORMAT...)  rtLog_WarnPrint("RTMESSAGE",FORMAT)
-#define rtLog_Error(FORMAT...) rtLog_ErrorPrint("RTMESSAGE",FORMAT)
-#define rtLog_Fatal(FORMAT...) rtLog_FatalPrint("RTMESSAGE",FORMAT)
+#define rtLog_Debug(FORMAT,...) rtLog_DebugPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
+#define rtLog_Info(FORMAT,...)  rtLog_InfoPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
+#define rtLog_Warn(FORMAT,...)  rtLog_WarnPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
+#define rtLog_Error(FORMAT,...) rtLog_ErrorPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
+#define rtLog_Fatal(FORMAT,...) rtLog_FatalPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/src/rtmessage/rtLog.h
+++ b/src/rtmessage/rtLog.h
@@ -82,19 +82,19 @@ rtLoggerSelection rtLog_GetOption();
 #define RT_PRINTF_FORMAT(IDX, FIRST)
 #endif
 
-void rtLogPrintfFmt (rtLogLevel level, const char* pModule, const char* file, int line, const char* format, ...) RT_PRINTF_FORMAT(5, 6);
+void rtLogPrintf(rtLogLevel level, const char* pModule, const char* file, int line, const char* format, ...) RT_PRINTF_FORMAT(5, 6);
 
-#define rtLog_DebugFmt(mod,FORMAT...)  rtLogPrintfFmt(RT_LOG_DEBUG, mod,__FILE__, __LINE__, FORMAT)
-#define rtLog_InfoFmt(mod,FORMAT...)   rtLogPrintfFmt(RT_LOG_INFO, mod, __FILE__, __LINE__, FORMAT)
-#define rtLog_WarnFmt(mod,FORMAT...)   rtLogPrintfFmt(RT_LOG_WARN, mod, __FILE__, __LINE__, FORMAT)
-#define rtLog_ErrorFmt(mod,FORMAT...)  rtLogPrintfFmt(RT_LOG_ERROR, mod, __FILE__, __LINE__, FORMAT)
-#define rtLog_FatalFmt(mod,FORMAT...)  rtLogPrintfFmt(RT_LOG_FATAL, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_DebugPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_DEBUG, mod,__FILE__, __LINE__, FORMAT)
+#define rtLog_InfoPrint(mod,FORMAT...)   rtLogPrintf(RT_LOG_INFO, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_WarnPrint(mod,FORMAT...)   rtLogPrintf(RT_LOG_WARN, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_ErrorPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_ERROR, mod, __FILE__, __LINE__, FORMAT)
+#define rtLog_FatalPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_FATAL, mod, __FILE__, __LINE__, FORMAT)
 
-#define rtLog_Debug(FORMAT...) rtLog_DebugFmt("RTMESSAGE",FORMAT)
-#define rtLog_Info(FORMAT...)  rtLog_InfoFmt("RTMESSAGE",FORMAT)
-#define rtLog_Warn(FORMAT...)  rtLog_WarnFmt("RTMESSAGE",FORMAT)
-#define rtLog_Error(FORMAT...) rtLog_ErrorFmt("RTMESSAGE",FORMAT)
-#define rtLog_Fatal(FORMAT...) rtLog_FatalFmt("RTMESSAGE",FORMAT)
+#define rtLog_Debug(FORMAT...) rtLog_DebugPrint("RTMESSAGE",FORMAT)
+#define rtLog_Info(FORMAT...)  rtLog_InfoPrint("RTMESSAGE",FORMAT)
+#define rtLog_Warn(FORMAT...)  rtLog_WarnPrint("RTMESSAGE",FORMAT)
+#define rtLog_Error(FORMAT...) rtLog_ErrorPrint("RTMESSAGE",FORMAT)
+#define rtLog_Fatal(FORMAT...) rtLog_FatalPrint("RTMESSAGE",FORMAT)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
RDKB-45280:Update the rtLog to support RDKLogger appropriately and modify rbus and rbuscore to use the rtLog Macro

Reason for change:Update the rtLog to support RDKLogger appropriately and modify rbus and rbuscore to use the rtLog Macro Test Procedure: Tested on VM: Run-rtrouted for RTMESSAGE log (Terminal1), RbusProvider(Term2) and rbuscli or rbusConsumer For RBUS logs(Term3), rbus_session_mgr For RBUSCORE logs(Term4) Risks: Low
Priority: P1

Signed-off-by: Deepak <deepak_m@comcast.com>