### PR TITLE
RDKB-45530: Memory leak in rbus_gtest.bin

### DIFF
--- a/include/rbus.h
+++ b/include/rbus.h
@@ -506,9 +506,19 @@ typedef rbusError_t (*rbusMethodHandler_t)(
  *                              also provided, it would publish only when the filter is triggered
  *  @param      autoPublish     output parameter used to disable the default behaviour
  *                              where rbus automatically publishing events for provider
- *                              data elements.  Providers can set autoPublish to false
- *                              if they would like to publish events directly for the 
- *                              data element associated with eventName.
+ *                              data elements. When providers set autoPublish to true
+ *                              the value will be checked once per second and the
+ *                              maximum event rate is one event per two seconds. If faster
+ *                              eventing or real-time eventing is required providers
+ *                              can set autoPublish to false and implement a custom
+ *                              approach. For fastest response time and to avoid missing
+ *                              changes that occur faster than once per second, the
+ *                              preferred way is to use a callback triggered from the
+ *                              lowest level of code to detect a value change. This
+ *                              callback may be invoked by vendor code via a HAL API or
+ *                              other method.  This callback can be received by the
+ *                              component that provides this event and used to send the
+ *                              publish message in real time.
  *  @return                     RBus error code as defined by rbusError_t.
  */
 typedef rbusError_t (* rbusEventSubHandler_t)(

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2132,6 +2132,7 @@ rbusCoreError_t rbus_discoverRegisteredComponents(int * count, char *** componen
     if(NULL == g_connection)
     {
         RBUSCORELOG_ERROR("Not connected.");
+        rtMessage_Release(out);
         return RBUSCORE_ERROR_INVALID_STATE;
     }
 
@@ -2176,7 +2177,7 @@ rbusCoreError_t rbus_discoverRegisteredComponents(int * count, char *** componen
         }
 
         rtMessage_Release(msg);
-
+        rtMessage_Release(out);
         ret = RBUSCORE_SUCCESS;
     }
     else

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1697,7 +1697,11 @@ static void _get_callback_handler (rbusHandle_t handle, rbusMessage request, rbu
                     }
                     /* Release the memory */
                     rbusProperty_Release(xproperties);
-
+                    for (i = 0; i < paramSize; i++)
+                    {
+                        rbusProperty_Release(properties[i]);
+                    }
+                    free (properties);
                     return;
                 }
                 else
@@ -4023,7 +4027,6 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
         rtVector_PushBack(handleInfo->eventSubs, sub);
 
         RBUSLOG_INFO("%s: %s subscribe retries succeeded", __FUNCTION__, eventName);
-        
         return RBUS_ERROR_SUCCESS;
     }
     else

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -874,6 +874,13 @@ int subscribeHandlerImpl(
 {
     rbusSubscription_t* subscription = NULL;
     struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
+    /*autoPublish is an output parameter used to disable the default behaviour where rbus automatically publishing events for
+    provider data elements. When providers set autoPublish to true the value will be checked once per second and the maximum event
+    rate is one event per two seconds. If faster eventing or real-time eventing is required providers can set autoPublish to false
+    and implement a custom approach. For fastest response time and to avoid missing changes that occur faster than once per second,
+    the preferred way is to use a callback triggered from the lowest level of code to detect a value change. This callback may be
+    invoked by vendor code via a HAL API or other method. This callback can be received by the component that provides this event
+    and used to send the publish message in real time.*/
     bool autoPublish = true;
 
     if(!el)

--- a/src/rbus/rbus_tokenchain.c
+++ b/src/rbus/rbus_tokenchain.c
@@ -70,12 +70,12 @@
 
 TokenChain* TokenChain_create(char const* sourceName, elementNode* regNode)
 {
-    TokenChain* chain;
+    TokenChain* chain = NULL;
     Token* next = NULL;
     int nameLen;
-    char* name;
-    char* ptr;
-    elementNode* node;
+    char* name = NULL;
+    char* ptr = NULL;
+    elementNode* node = NULL;
 
     if(regNode == NULL)
     {

--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -1486,7 +1486,10 @@ rtConnection_Read(rtConnection con, int32_t timeout)
     return rtErrorFromErrno(ENOMEM);
 
   if (!con)
+  {
+    rtMessageInfo_Release(msginfo);
     return rtErrorFromErrno(EINVAL);
+  }
 
   // TODO: no error handling right now, all synch I/O
 
@@ -1532,7 +1535,7 @@ rtConnection_Read(rtConnection con, int32_t timeout)
       {
         msginfo->data = (uint8_t *)rt_try_malloc(msginfo->header.payload_length + 1);
         if(!msginfo->data)
-          return rtErrorFromErrno(ENOMEM);        
+          return rtErrorFromErrno(ENOMEM);
         msginfo->dataCapacity = msginfo->header.payload_length + 1;
       }
 

--- a/unittests/rbusConsumer.cpp
+++ b/unittests/rbusConsumer.cpp
@@ -142,7 +142,10 @@ static int exec_rbus_multi_test(rbusHandle_t handle, int expectedRc, int numProp
   rc = rbus_setMulti(handle, numProps, next, NULL);
   EXPECT_EQ(rc,expectedRc);
 
+  rbusValue_Release(setVal1);
+  rbusValue_Release(setVal2);
   rbusProperty_Release(next);
+  rbusProperty_Release(last);
 
   return rc;
 }
@@ -808,6 +811,7 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
         rc = rbusMethod_Invoke(handle, method, inParams, &outParams);
         rbusObject_Release(inParams);
         EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
+        rbusProperty_Release(prop);
 
         if(RBUS_ERROR_SUCCESS == rc)
           rbusObject_Release(outParams);
@@ -836,6 +840,7 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
           rc = rbusMethod_Invoke(handle, method, inParams, &outParams);
           rbusObject_Release(inParams);
           EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
+          rbusProperty_Release(prop);
           if(rc == RBUS_ERROR_SUCCESS)
           {
             rbusObject_Release(outParams);
@@ -858,7 +863,7 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
         rbusObject_Release(inParams);
         EXPECT_NE(rc, RBUS_ERROR_SUCCESS);
         rc=0;
-
+        rbusProperty_Release(prop);
         if(outParams)
         {
           rbusObject_fwrite(outParams, 1, stdout);
@@ -881,7 +886,7 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
         rbusObject_Release(inParams);
         EXPECT_NE(rc, RBUS_ERROR_SUCCESS);
         rc=0;
-
+        rbusProperty_Release(prop);
         if(outParams)
         {
           rbusObject_fwrite(outParams, 1, stdout);
@@ -905,6 +910,7 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
         printf("consumer: rbusMethod_InvokeAsync(%s) %s\n", "Device.rbusProvider.MethodAsync1()",
             rc == RBUS_ERROR_SUCCESS ? "success" : "fail");
         sleep(runtime);
+        rbusObject_Release(inParams);
 
       }
       break;
@@ -925,6 +931,7 @@ int rbusConsumer(rbusGtest_t test, pid_t pid, int runtime)
          printf("consumer: rbusMethod_InvokeAsync(%s) %s\n", "Device.rbusProvider.MethodAsync_2()",
          rc == RBUS_ERROR_SUCCESS ? "success" : "fail");
          sleep(runtime);
+         rbusObject_Release(inParams);
       }
       break;
     case RBUS_GTEST_REG_ROW:

--- a/unittests/rbusTokenTest.cpp
+++ b/unittests/rbusTokenTest.cpp
@@ -79,9 +79,9 @@ TEST(rbusTokenTest, negtestToken5)
 {
   TokenChain* tokens;
   char const* eventName="Device.rbusProvider.Param1";
-  elementNode* registryElem = (elementNode *)malloc(sizeof(elementNode));
+  elementNode* registryElem = (elementNode *)calloc(1,sizeof(elementNode));
 
-  registryElem->parent = (elementNode *)malloc(sizeof(elementNode)); 
+  registryElem->parent = (elementNode *)calloc(1,sizeof(elementNode));
 
   tokens = TokenChain_create(eventName, registryElem);
   EXPECT_EQ(tokens,nullptr);

--- a/unittests/rbus_unit_test_client.cpp
+++ b/unittests/rbus_unit_test_client.cpp
@@ -185,7 +185,7 @@ static bool CALL_RBUS_PULL_OBJECT_DETAILED(char* server_obj, test_struct_t expec
 
 rbusCoreError_t CREATE_SESSION()
 {
-    rbusMessage response;
+    rbusMessage response = NULL;
     rbusCoreError_t ret = RBUSCORE_SUCCESS;
 
     ret = rbus_invokeRemoteMethod(RBUS_SMGR_DESTINATION_NAME, RBUS_SMGR_METHOD_REQUEST_SESSION_ID, NULL, 1000, &response);
@@ -198,6 +198,7 @@ rbusCoreError_t CREATE_SESSION()
             {
                 printf("ERROR Cannot create a new session, Session already exist \n");
                 ret = RBUSCORE_ERROR_INVALID_STATE;
+                rbusMessage_Release(response);
                 return ret;
             }
         }
@@ -205,6 +206,7 @@ rbusCoreError_t CREATE_SESSION()
         {
             printf("Got new session id %d\n", g_current_session_id);
             ret = RBUSCORE_SUCCESS;
+            rbusMessage_Release(response);
             return ret;
         }
         else{
@@ -214,6 +216,7 @@ rbusCoreError_t CREATE_SESSION()
     else{
         printf("RPC with session manager failed.\n");
         ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+        rbusMessage_Release(response);
         return ret;
     }
     return ret;
@@ -221,7 +224,7 @@ rbusCoreError_t CREATE_SESSION()
 
 rbusCoreError_t PRINT_CURRENT_SESSION_ID()
 {
-    rbusMessage response;
+    rbusMessage response = NULL;
     rbusCoreError_t ret = RBUSCORE_SUCCESS;
 
     ret = rbus_invokeRemoteMethod(RBUS_SMGR_DESTINATION_NAME, RBUS_SMGR_METHOD_GET_CURRENT_SESSION_ID, NULL, 1000, &response);
@@ -235,6 +238,7 @@ rbusCoreError_t PRINT_CURRENT_SESSION_ID()
             {
                 printf("Session manager reports internal error %d.\n", result);
                 ret = RBUSCORE_ERROR_INVALID_STATE;
+                rbusMessage_Release(response);
                 return ret;
             }
         }
@@ -242,6 +246,7 @@ rbusCoreError_t PRINT_CURRENT_SESSION_ID()
         {
             printf("Current session id %d\n", g_current_session_id);
             ret = RBUSCORE_SUCCESS;
+            rbusMessage_Release(response);
             return ret;
         }
         else{
@@ -251,6 +256,7 @@ rbusCoreError_t PRINT_CURRENT_SESSION_ID()
     else{
         printf("RPC with session manager failed.\n");
         ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+        rbusMessage_Release(response);
         return ret;
     }
     return ret;
@@ -259,7 +265,7 @@ rbusCoreError_t PRINT_CURRENT_SESSION_ID()
 rbusCoreError_t END_SESSION(int session)
 {
     rbusMessage out;
-    rbusMessage response;
+    rbusMessage response = NULL;
 
     rbusMessage_Init(&out);
     rbusMessage_SetInt32(out, session);
@@ -274,11 +280,13 @@ rbusCoreError_t END_SESSION(int session)
             {
                 printf("ERROR Cannot end session, It doesn't match active session\n");
                 ret = RBUSCORE_ERROR_INVALID_STATE;
+                rbusMessage_Release(response);
                 return ret;
             }
             else{
                 printf("Successfully ended session %d.\n", session);
                 ret = RBUSCORE_SUCCESS;
+                rbusMessage_Release(response);
                 return ret;
             }
         }
@@ -286,6 +294,7 @@ rbusCoreError_t END_SESSION(int session)
     else{
         printf("RPC with session manager failed.\n");
         ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+        rbusMessage_Release(response);
         return ret;
     }
     return ret;

--- a/unittests/rbus_unit_test_multiple_servers.cpp
+++ b/unittests/rbus_unit_test_multiple_servers.cpp
@@ -227,8 +227,8 @@ TEST_F(MultipleServerTest, rbus_multipleServer_test1)
     if(is_parent)
     {
         sleep(2);
-        int num_comps;
-        char** components;
+        int num_comps = 0;
+        char** components = NULL;
         rbusCoreError_t err;
         //Neg test discover Registered components without connection
         err = rbus_discoverRegisteredComponents(&num_comps, &components);


### PR DESCRIPTION
Reason for change: Memory leak in rbus_gtest.bin
Test Procedure: run rbus_gtest.bin with valgrind
Risks: Low

Signed-off-by: Deepthi <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>