### PR TITLE
RDKB-45652: Can't find destination component for multiple parameters

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1964,7 +1964,7 @@ static void _table_add_row_callback_handler (rbusHandle_t handle, rbusMessage re
     if(err != RT_OK || (aliasName && strlen(aliasName)==0))
         aliasName = NULL;
 
-    RBUSLOG_DEBUG("%s table [%s] alias [%s] err [%d]", __FUNCTION__, tableName, aliasName, err);
+    RBUSLOG_DEBUG("%s table [%s] alias [%s] name [%s]", __FUNCTION__, tableName, aliasName, handleInfo->componentName);
 
     elementNode* tableRegElem = retrieveElement(handleInfo->elementRoot, tableName);
     elementNode* tableInstElem = retrieveInstanceElement(handleInfo->elementRoot, tableName);

--- a/src/rtmessage/rtRoutingTree.c
+++ b/src/rtmessage/rtRoutingTree.c
@@ -481,7 +481,7 @@ rtError rtRoutingTree_AddTopicRoute(rtRoutingTree rt, const char* topicPath, con
     return RT_OK;
 }
 
-void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes)
+void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes, int discoverall)
 {
     int i;
     *routes = NULL;
@@ -545,7 +545,7 @@ void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* r
         }
 #endif
     }
-    if(treeTopic->isTable)
+    if((treeTopic->isTable) && (!discoverall))
     {
         /* If we ended on a table, then we need an additional check.
           We allow querying a table without adding the ".{i}" suffix.

--- a/src/rtmessage/rtRoutingTree.h
+++ b/src/rtmessage/rtRoutingTree.h
@@ -154,7 +154,7 @@ typedef struct _rtRoutingTree
 void rtRoutingTree_Create(rtRoutingTree* rt);
 void rtRoutingTree_Destroy(rtRoutingTree rt);
 rtError rtRoutingTree_AddTopicRoute(rtRoutingTree rt, const char* topic, const void* route, int err_on_dup);
-void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes);
+void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes, int discoverall);
 void rtRoutingTree_GetRouteTopics(rtRoutingTree rt, const void* route, rtList* topics);
 void rtRoutingTree_RemoveRoute(rtRoutingTree rt, const void* route);
 void rtRoutingTree_RemoveTopic(rtRoutingTree rt, const char* topic);

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -549,7 +549,7 @@ rtRouted_SendMessage(rtMessageHeader * request_hdr, rtMessage message, rtConnect
 
   /*Find the route to populate control_id field.*/
   rtRouteEntry *route = NULL;
-  rtRoutingTree_GetTopicRoutes(routingTree, request_hdr->topic, &list);
+  rtRoutingTree_GetTopicRoutes(routingTree, request_hdr->topic, &list, 0);
   if(list)
   {
     rtList_GetFront(list, &item);
@@ -1146,7 +1146,7 @@ rtRouted_OnMessageDiscoverElementObjects(rtConnectedClient* sender, rtMessageHea
           rtList routes;
           rtListItem item;
           int set = 0;
-          rtRoutingTree_GetTopicRoutes(routingTree, expression, &routes);
+          rtRoutingTree_GetTopicRoutes(routingTree, expression, &routes, 1);
           if(routes)
           {
             size_t count;
@@ -1456,7 +1456,7 @@ rtRouter_DispatchMessageFromClient(rtConnectedClient* clnt)
   START_TRACKING();
 dispatch:
 
-  rtRoutingTree_GetTopicRoutes(routingTree, clnt->header.topic, &list);
+  rtRoutingTree_GetTopicRoutes(routingTree, clnt->header.topic, &list, 0);
   if(list)
   {
     rtList_GetFront(list, &item);


### PR DESCRIPTION
Reason for change: Made changes to discover all the components owner for the wild card query and send notification only to the data model registered component in case of addition and deletion of property/table
Test Procedure: Test and verified
Risks: Medium
Priority: P0
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>