### PR TITLE
[CI][AUTO] Xw4 Version retrieved are different after CDL - RDKLOGGER is not ON in xCAM2 and xCAM3

### DIFF
--- a/rdk_build.sh
+++ b/rdk_build.sh
@@ -138,7 +138,7 @@ function configure()
     echo "rbus Compiling started"
     mkdir -p ${RDK_PROJECT_ROOT_PATH}/opensource/src/rbus/build
     cd ${RDK_PROJECT_ROOT_PATH}/opensource/src/rbus/build
-    cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_PREFIX_PATH=${SEARCH_PATH} -DENABLE_RDKLOGGER=OFF -DRDKC_BUILD=ON -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${RDK_FSROOT_PATH}/usr/lib" ${EXTRA_OPTIONS} ..
+    cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_PREFIX_PATH=${SEARCH_PATH} -DENABLE_RDKLOGGER=ON -DRDKC_BUILD=ON -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${RDK_FSROOT_PATH}/usr/lib" ${EXTRA_OPTIONS} ..
 }
 
 function clean()

--- a/src/rtmessage/CMakeLists.txt
+++ b/src/rtmessage/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(rtMessage -pthread ${CJSON_LIBRARIES})
 
 if (ENABLE_RDKLOGGER)
     add_dependencies(rtMessage rdklogger)
-    target_link_libraries(rtMessage -lrdkloggers)
+    target_link_libraries(rtMessage ${RDKLOGGER_LIBRARIES})
 endif (ENABLE_RDKLOGGER)
 
 if (OPENSSL_REQUIRED)


### PR DESCRIPTION
RDKC-12575:[CI][AUTO] Xw4 Version retrieved are different after CDL - RDKLOGGER is not ON in xCAM2 and xCAM3

Reason for change: Enabled ENABLE_RDKLOGGER=ON in rdk_build.sh Test Procedure: Trigger RDKC Build and test, tested on Local builld PC, Test on jenkins Risks: Med
Priority: P0

Signed-off-by: Deepak <deepak_m@comcast.com>