### PR TITLE
RDKC-12563,RDKB-45841 - Continuous flooding seen in various logs from RBUS module

### DIFF
--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -235,7 +235,7 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
   else if (sOption == RT_USE_RDKLOGGER)
   {
     char module[MODULE_BUFFER_SIZE] = {0};
-    rdk_LogLevel rdklevel = rdkLogLevelFromrtLogLevel(level);
+    rdk_LogLevel rdklevel = rdkLogLevelFormatLogLevel(level);
     sprintf(module, "LOG.RDK.%s", mod);
     RDK_LOG(rdklevel, module, buff);
   }

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -175,6 +175,32 @@ rtLoggerSelection rtLog_GetOption()
   return sOption;
 }
 
+#ifdef ENABLE_RDKLOGGER
+rdk_LogLevel rdkLogLevelFormatLogLevel(rtLogLevel level)
+{
+  rdk_LogLevel rdklevel = RDK_LOG_INFO;
+  switch (level)
+  {
+    case RT_LOG_FATAL:
+      rdklevel = RDK_LOG_FATAL;
+      break;
+    case RT_LOG_ERROR:
+      rdklevel = RDK_LOG_ERROR;
+      break;
+    case RT_LOG_WARN:
+      rdklevel = RDK_LOG_WARN;
+      break;
+    case RT_LOG_INFO:
+      rdklevel = RDK_LOG_INFO;
+      break;
+    case RT_LOG_DEBUG:
+      rdklevel = RDK_LOG_DEBUG;
+      break;
+  }
+  return rdklevel;
+}
+#endif
+
 #define RT_LOG_BUFFER_SIZE    1024
 #define MODULE_BUFFER_SIZE    64
 void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, const char* format, ...)
@@ -209,8 +235,9 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
   else if (sOption == RT_USE_RDKLOGGER)
   {
     char module[MODULE_BUFFER_SIZE] = {0};
+    rdk_LogLevel rdklevel = rdkLogLevelFromrtLogLevel(level);
     sprintf(module, "LOG.RDK.%s", mod);
-    RDK_LOG(level, module, buff);
+    RDK_LOG(rdklevel, module, buff);
   }
 #endif
   else

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -176,7 +176,7 @@ rtLoggerSelection rtLog_GetOption()
 }
 
 #ifdef ENABLE_RDKLOGGER
-rdk_LogLevel rdkLogLevelFormatLogLevel(rtLogLevel level)
+rdk_LogLevel rdkLogLevelFromrtLogLevel(rtLogLevel level)
 {
   rdk_LogLevel rdklevel = RDK_LOG_INFO;
   switch (level)
@@ -235,7 +235,7 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
   else if (sOption == RT_USE_RDKLOGGER)
   {
     char module[MODULE_BUFFER_SIZE] = {0};
-    rdk_LogLevel rdklevel = rdkLogLevelFormatLogLevel(level);
+    rdk_LogLevel rdklevel = rdkLogLevelFromrtLogLevel(level);
     sprintf(module, "LOG.RDK.%s", mod);
     RDK_LOG(rdklevel, module, buff);
   }


### PR DESCRIPTION
RDKC-12563: Continuous flooding seen in various logs from RTMESSAGE and RBUS module 
RDKB-45841 : Log files are empty after 5 min uptime after upgrade/reboot/FR

Reason for change: Change for RDK logger for we used the rtLogLevel_t as is to pass to RDKLogger for rdk_LogLevel which is wrong,  RT_LOG_DEBUG is 0 where as RDK_LOG_FATAL is also 0. So this lead all the debug to be printed as FATAL and similarly, all the INFO to be printed as ERROR. Test Procedure: Trigger RDKC and RDKB Build and test by flashing respective images and verify Logs of on Device. Risks: Med
Priority: P0

Signed-off-by: Deepak <deepak_m@comcast.com>