### PR TITLE
RDKB-44725: rbuscli set failing when commit field is passed

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -41,7 +41,7 @@
 #define RBUS_CLI_COMPONENT_NAME "rbuscli"
 #define RBUS_CLI_MAX_PARAM      25
 #define RBUS_CLI_MAX_CMD_ARG    (RBUS_CLI_MAX_PARAM * 3)
-#define RBUS_CLI_SESSION_ID     4230
+#define RBUS_CLI_SESSION_ID     0
 #define BT_BUF_SIZE 512
 
 


### PR DESCRIPTION
Reason for change: rbuscli set failing when commit field is passed. 
Test Procedure: execute command set Device.X_RDK_WanManager.CPEInterface.1.Wan.Name string wan0 false in rbuscli 
Risks: Low

Signed-off-by: Deepthi DEEPTHICHANDRASHEKAR_SHETTY@comcast.com