### PR TITLE
RDKB-45774:[TDK][AUTO][22Q4_SPRINT][CCSPCOMMON_MBUS]CcspBaseIf_informEndOfSession API returns failure with status 102

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4689,11 +4689,16 @@ rbusError_t rbus_closeSession(rbusHandle_t handle, uint32_t sessionId)
     rbusError_t rc = RBUS_ERROR_SUCCESS;
     rbusCoreError_t err = RBUSCORE_SUCCESS;
 
-    if ((0 != sessionId) && (handle))
+    if (handle)
     {
         rbusMessage inputSession;
         rbusMessage response = NULL;
 
+        if (sessionId == 0)
+        {
+            RBUSLOG_WARN("Passing default session ID which is 0");
+            return RBUS_ERROR_SUCCESS;
+        }
         rbusMessage_Init(&inputSession);
         rbusMessage_SetInt32(inputSession, /*MESSAGE_FIELD_PAYLOAD,*/ sessionId);
         if((err = rbus_invokeRemoteMethod(RBUS_SMGR_DESTINATION_NAME, RBUS_SMGR_METHOD_END_SESSION, inputSession, rbusConfig_ReadSetTimeout(), &response)) == RBUSCORE_SUCCESS)

--- a/unittests/rbusApiNegTest.cpp
+++ b/unittests/rbusApiNegTest.cpp
@@ -879,7 +879,7 @@ TEST(rbusSessionNegTest, test5)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbus_closeSession(handle, 0);
-    EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
     free(handle);
 }
 
@@ -891,7 +891,7 @@ TEST(rbusSessionNegTest, test6)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbus_closeSession(handle, sessionId);
-    EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
     free(handle);
 }
 


### PR DESCRIPTION
Reason for change: CcspBaseIf_informEndOfSession API returns failure with status 102 
Test Procedure: CcspBaseIf_informEndOfSession API should return success 
Risks: Low

Signed-off-by: Deepthi <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>