### PR TITLE
RBUS cli utility doesn't have the provision to given the interval as argument

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -1749,7 +1749,7 @@ void validate_and_execute_subscribe_cmd (int argc, char *argv[], bool add, bool 
 	    strcat(userData, " ");
 	    strcat(userData, argv[3]);
 	}
-	else if (find_filter(argv) >= 0)
+	else if ((relOp = find_filter(argv)) >= 0)
         {
             strcat(userData, " ");
             strcat(userData, argv[3]);


### PR DESCRIPTION
 RDKB-45878: RBUS cli utility doesn't have the provision to give the interval as argument
    Reason for change: Added interval based subscription
    Test Procedure: execute command "subint <event> <interval> in rbuscli
    Risks: Low
    Priority: P0
    Signed-off-by: Netaji Panigrahi <Netaji_Panigrahi@comcast.com>