### PR TITLE
RDKB-45335: [TDK][AUTO][22Q4_Sprint] SET SESSION ID API Validation is returning failure

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4651,8 +4651,13 @@ rbusError_t rbus_getCurrentSession(rbusHandle_t handle, uint32_t *pSessionId)
     rbusCoreError_t err = RBUSCORE_SUCCESS;
     rbusMessage response = NULL;
 
-    if (pSessionId && handle)
+    if (handle)
     {
+	if(pSessionId == 0)
+        {
+            RBUSLOG_WARN("Passing default session ID which is 0");
+            return RBUS_ERROR_SUCCESS;
+        }
         *pSessionId = 0;
         if((err = rbus_invokeRemoteMethod(RBUS_SMGR_DESTINATION_NAME, RBUS_SMGR_METHOD_GET_CURRENT_SESSION_ID, NULL, rbusConfig_ReadGetTimeout(), &response)) == RBUSCORE_SUCCESS)
         {

--- a/unittests/rbusApiNegTest.cpp
+++ b/unittests/rbusApiNegTest.cpp
@@ -857,7 +857,7 @@ TEST(rbusSessionNegTest, test3)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbus_getCurrentSession(handle , NULL);
-    EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc, RBUS_ERROR_SUCCESS);
     free(handle);
 }
 


### PR DESCRIPTION
Reason for change: CcspBaseIf_informEndOfSession API returns failure with status 102 Test Procedure: CcspBaseIf_informEndOfSession API should return success Risks: Low

Signed-off-by: Deepthi <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>