### PR TITLE
RDKB-45942: Provider Crashed with Active Subscription is not publishng after restart

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1013,7 +1013,16 @@ static void registerTableRow (rbusHandle_t handle, elementNode* tableInstElem, c
         {
             RBUSLOG_WARN("failed to publish ObjectCreated event err:%d", respub);
         }
-
+        if(rowElem)
+        {
+            elementNode* child = rowElem->child;
+            while(child)
+            {
+                const char* eventName = child->fullName;
+                rbusSubscriptions_resubscribeCache(handle, handleInfo->subscriptions, eventName, child);
+                child = child->nextSibling;
+            }
+        }
         rbusValue_Release(rowNameVal);
         rbusValue_Release(instNumVal);
         rbusValue_Release(aliasVal);


### PR DESCRIPTION
Reason for change: Provider Crashed with Active Subscription is not publishing after restart 
Test Procedure: Test and verified
Risks: Medium
Priority: P1

Signed-off-by: Deepthi <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>