### PR TITLE
RDKB-44740 RDKB-44861 : RBUS Subscribe API to get Initial Value

### DIFF
--- a/include/rbus.h
+++ b/include/rbus.h
@@ -226,7 +226,10 @@ typedef enum
                                     was deleted in table. */
     RBUS_EVENT_VALUE_CHANGED,  /**< Notification that a property value
                                     was changed. */
-    RBUS_EVENT_GENERAL         /**< Provider defined event.*/
+    RBUS_EVENT_GENERAL,        /**< Provider defined event.*/
+    RBUS_EVENT_INITIAL_VALUE,  /**< Notification of initial value immediately
+                                    after subscription*/
+    RBUS_EVENT_INTERVAL,       /**< For event with interval*/
 } rbusEventType_t;
 
 /**
@@ -301,6 +304,7 @@ typedef struct _rbusEventSubscription
     void*               userData;   /** The userData set when subscribing to the event. */
     rbusHandle_t        handle;     /** Private use only: The rbus handle associated with this subscription */
     rbusSubscribeAsyncRespHandler_t asyncHandler;/** Private use only: The async handler being used for any background subscription retries */
+    bool                publishOnSubscribe;
 } rbusEventSubscription_t;
 
 /** @} */

--- a/sampleapps/consumer/rbusEventConsumer.c
+++ b/sampleapps/consumer/rbusEventConsumer.c
@@ -147,8 +147,8 @@ int main(int argc, char *argv[])
     rbusHandle_t handle;
     char* data[2] = { "My Data 1", "My Data2" };
     rbusEventSubscription_t subscriptions[2] = {
-        {"Device.Provider1.Event1!", NULL, 0, 0, generalEvent1Handler, data[0], NULL, NULL},
-        {"Device.Provider1.Event2!", NULL, 0, 0, generalEvent2Handler, data[1], NULL, NULL}
+        {"Device.Provider1.Event1!", NULL, 0, 0, generalEvent1Handler, data[0], NULL, NULL, true},
+        {"Device.Provider1.Event2!", NULL, 0, 0, generalEvent2Handler, data[1], NULL, NULL, true}
     };
 
     printf("constumer: start\n");

--- a/sampleapps/consumer/rbusValueChangeConsumer.c
+++ b/sampleapps/consumer/rbusValueChangeConsumer.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
     rbusHandle_t handle;
     rbusFilter_t filter;
     rbusValue_t filterValue;
-    rbusEventSubscription_t subscription = {"Device.Provider1.Param1", NULL, 0, 0, eventReceiveHandler, NULL, NULL, NULL};
+    rbusEventSubscription_t subscription = {"Device.Provider1.Param1", NULL, 0, 0, eventReceiveHandler, NULL, NULL, NULL, false};
 
     rc = rbus_open(&handle, "EventConsumer");
     if(rc != RBUS_ERROR_SUCCESS)

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -338,7 +338,7 @@ static int unlock()
 	return pthread_mutex_unlock(&g_mutex);
 }
 
-static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout);
+static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response);
 
 static void perform_init()
 {
@@ -371,7 +371,7 @@ static void perform_cleanup()
             for(i2 = 0; i2 < sz2; i2++)
             {   
                 client_event_t event = rtVector_At(sub->events, i2);
-                send_subscription_request(sub->object, event->name, false, NULL, NULL, 0);
+                send_subscription_request(sub->object, event->name, false, NULL, NULL, 0, false, NULL);
             }
         }
         lock();
@@ -654,7 +654,7 @@ rtConnection rbus_getConnection()
     return g_connection;
 }
 
-static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout_ms)
+static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout_ms, bool publishOnSubscribe, rbusMessage *response)
 {
     /* Method definition to add new event subscription: 
      * method name: METHOD_ADD_EVENT_SUBSCRIPTION / METHOD_REMOVE_EVENT_SUBSCRIPTION.
@@ -663,7 +663,7 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
      * integer, mapped to key MESSAGE_FIELD_RESULT. 0 is success. Anything else is a failure. */
     rbusCoreError_t ret;
 
-    rbusMessage request, response;
+    rbusMessage request, internal_response;
     rbusMessage_Init(&request);
 
     rbusMessage_SetString(request, event_name);
@@ -671,16 +671,19 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
     rbusMessage_SetInt32(request, payload ? 1 : 0);
     if(payload)
         rbusMessage_SetMessage(request, payload);
+    if(publishOnSubscribe)
+        rbusMessage_SetInt32(request, 1); /*for publishOnSubscribe */
 
     if(timeout_ms <= 0)
         timeout_ms = TIMEOUT_VALUE_FIRE_AND_FORGET;
-    ret = rbus_invokeRemoteMethod(object_name, (activate? METHOD_ADD_EVENT_SUBSCRIPTION : METHOD_REMOVE_EVENT_SUBSCRIPTION),
-            request, timeout_ms, &response);
+    ret = rbus_invokeRemoteMethod(object_name, (activate? METHOD_SUBSCRIBE : METHOD_UNSUBSCRIBE),
+            request, timeout_ms, &internal_response);
     if(RBUSCORE_SUCCESS == ret)
     {
         rtError extract_ret;
         int result;
-        extract_ret = rbusMessage_GetInt32(response, &result);
+
+        extract_ret = rbusMessage_GetInt32(internal_response, &result);
         if(RT_OK == extract_ret)
         {
             if(RBUSCORE_SUCCESS == result)
@@ -704,7 +707,10 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
             RBUSCORELOG_ERROR("Error adding subscription for %s::%s. Received unexpected response.", object_name, event_name);
             ret = RBUSCORE_ERROR_MALFORMED_RESPONSE;
         }
-        rbusMessage_Release(response);
+        if(response != NULL)
+            *response = internal_response;
+        if(!activate)
+            rbusMessage_Release(internal_response);
     }
     else if(RBUSCORE_ERROR_DESTINATION_UNREACHABLE == ret)
     {
@@ -1483,7 +1489,7 @@ static rbusCoreError_t remove_subscription_callback(const char * object_name,  c
     return ret;
 }
 
-static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout)
+static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response)
 {
     /*using namespace rbus_client;*/
     rbusCoreError_t ret = RBUSCORE_SUCCESS;
@@ -1556,7 +1562,7 @@ static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  
 
     unlock();
 
-    if((ret = send_subscription_request(object_name, event_name, true, payload, providerError, timeout)) != RBUSCORE_SUCCESS)
+    if((ret = send_subscription_request(object_name, event_name, true, payload, providerError, timeout, publishOnSubscribe, response)) != RBUSCORE_SUCCESS)
     {
         if(g_master_event_callback == NULL)
         {
@@ -1571,12 +1577,12 @@ static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  
 
 rbusCoreError_t rbus_subscribeToEvent(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError)
 {
-    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, 0);
+    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, 0, false, NULL);
 }
 
-rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout)
+rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response)
 {
-    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, timeout);
+    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, timeout, publishOnSubscribe, response);
 }
 
 rbusCoreError_t rbus_unsubscribeFromEvent(const char * object_name,  const char * event_name, const rbusMessage payload)
@@ -1602,7 +1608,7 @@ rbusCoreError_t rbus_unsubscribeFromEvent(const char * object_name,  const char 
 
     if(!g_master_event_callback)
         remove_subscription_callback(object_name, event_name);
-    ret = send_subscription_request(object_name, event_name, false, payload, NULL, 0);
+    ret = send_subscription_request(object_name, event_name, false, payload, NULL, 0, false, NULL);
     return ret;
 }
 

--- a/src/core/rbuscore.h
+++ b/src/core/rbuscore.h
@@ -141,7 +141,7 @@ rbusCoreError_t rbus_subscribeToEvent(const char * object_name,  const char * ev
 /* Subscribe to 'event_name' events from 'object_name' object, with the specified timeout. If the timeout is less than or equal to zero, timeout will be set to 1000.
  * If the object supports only one event, event_name can be NULL. If the event_name is an alias for the object, then object_name can be NULL. The installed callback will be invoked every time 
  * a matching event is received. */
-rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout_ms);
+rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout_ms, bool publishOnSubscribe, rbusMessage *response);
 
 /* Unsubscribe from receiving 'event_name' events from 'object_name' object. If the object supports only one event, event_name can be NULL. */
 rbusCoreError_t rbus_unsubscribeFromEvent(const char * object_name,  const char * event_name, const rbusMessage payload);

--- a/src/core/rbuscore_types.h
+++ b/src/core/rbuscore_types.h
@@ -70,6 +70,8 @@ typedef enum _rbuscore_bus_status
 #define METHOD_DELETETBLROW "METHOD_DELETETBLROW"
 #define METHOD_RPC "METHOD_RPC"
 #define METHOD_RESPONSE "METHOD_RESPONSE"
+#define METHOD_SUBSCRIBE "METHOD_SUBSCRIBE"
+#define METHOD_UNSUBSCRIBE "METHOD_UNSUBSCRIBE"
 #define METHOD_MAX "METHOD_MAX"
 
 /*Message fields defined by rtwrapper*/

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2159,6 +2159,128 @@ static int _method_callback_handler(rbusHandle_t handle, rbusMessage request, rb
     }
 }
 
+static void _subscribe_callback_handler (rbusHandle_t handle, rbusMessage request, rbusMessage* response, char const* method)
+{
+    const char * sender = NULL;
+    const char * event_name = NULL;
+    int has_payload = 0;
+    rbusMessage payload = NULL;
+    int publishOnSubscribe = 0;
+    struct _rbusHandle* handleInfo = handle;
+
+    rbusMessage_Init(response);
+
+    if((RT_OK == rbusMessage_GetString(request, &event_name)) &&
+        (RT_OK == rbusMessage_GetString(request, &sender)))
+    {
+        /*Extract arguments*/
+        if((NULL == sender) || (NULL == event_name))
+        {
+            RBUSLOG_ERROR("Malformed subscription request. Sender: %s. Event: %s.", sender, event_name);
+            rbusMessage_SetInt32(*response, RBUSCORE_ERROR_INVALID_PARAM);
+        }
+        else
+        {
+            rbusMessage_GetInt32(request, &has_payload);
+            if(has_payload)
+                rbusMessage_GetMessage(request, &payload);
+            int added = strncmp(method, METHOD_SUBSCRIBE, MAX_METHOD_NAME_LENGTH) == 0 ? 1 : 0;
+            if(added)
+                rbusMessage_GetInt32(request, &publishOnSubscribe);
+            rbusCoreError_t ret = _event_subscribe_callback_handler(NULL, event_name, sender, added, payload, handle);
+            rbusMessage_SetInt32(*response, ret);
+            rbusMessage_SetInt32(*response, 1); /* Based on this value initial value will be published to the consumer in
+                                                   rbusEvent_SubscribeWithRetries() function call */
+
+            if(publishOnSubscribe)
+            {
+                elementNode* el = NULL;
+                rbusEvent_t event = {0};
+                rbusObject_t data = NULL;
+                rbusProperty_t tmpProperties = NULL;
+                rbusError_t err = RBUS_ERROR_SUCCESS;
+
+                rbusObject_Init(&data, NULL);
+                el = retrieveInstanceElement(handleInfo->elementRoot, event_name);
+                if(el->type == RBUS_ELEMENT_TYPE_TABLE)
+                {
+                    rbusMessage tableRequest = NULL;
+                    rbusMessage tableResponse = NULL;
+                    int tableRet = 0;
+                    int count = 0;
+                    int i = 0;
+
+                    rbusMessage_Init(&tableRequest);
+                    rbusMessage_SetString(tableRequest, event_name);
+                    rbusMessage_SetInt32(tableRequest, -1);
+                    rbusMessage_SetInt32(tableRequest, 1);
+                    _get_parameter_names_handler(handle, tableRequest, &tableResponse);
+                    rbusMessage_GetInt32(tableResponse, &tableRet);
+                    rbusMessage_GetInt32(tableResponse, &count);
+                    rbusProperty_Init(&tmpProperties, "numberOfEntries", NULL);
+                    if(count != 0)
+                    {
+                        for(i = 0; i < count; ++i)
+                        {
+                            int32_t instNum = 0;
+                            char fullName[RBUS_MAX_NAME_LENGTH] = {0};
+                            char row_instance[RBUS_MAX_NAME_LENGTH] = {0};
+                            char const* alias = NULL;
+
+                            rbusMessage_GetInt32(tableResponse, &instNum);
+                            rbusMessage_GetString(tableResponse, &alias);
+                            snprintf(fullName, RBUS_MAX_NAME_LENGTH, "%s%d.", event_name, instNum);
+                            if(i == 0)
+                            {
+                                rbusProperty_SetInt32(tmpProperties, count);
+                            }
+                            snprintf(row_instance, RBUS_MAX_NAME_LENGTH, "path%d", instNum);
+                            rbusProperty_AppendString(tmpProperties, row_instance, fullName);
+                        }
+                    }
+                    else
+                    {
+                        rbusProperty_SetInt32(tmpProperties, count);
+                    }
+                    rbusObject_SetProperty(data, tmpProperties);
+                }
+                else
+                {
+                    if(ret == RBUSCORE_SUCCESS && el->cbTable.getHandler)
+                    {
+                        rbusValue_t val = NULL;
+                        rbusGetHandlerOptions_t options;
+                        memset(&options, 0, sizeof(options));
+
+                        options.requestingComponent = handleInfo->componentName;
+                        rbusProperty_Init(&tmpProperties, event_name, NULL);
+                        err = el->cbTable.getHandler(handle, tmpProperties, &options);
+                        val = rbusProperty_GetValue(tmpProperties);
+                        rbusObject_SetValue(data, "initialValue", val);
+                    }
+                }
+                if (err == RBUS_ERROR_SUCCESS)
+                {
+
+                    event.name = event_name;
+                    event.type = RBUS_EVENT_INITIAL_VALUE;
+                    event.data = data;
+                    rbusEventData_appendToMessage(&event, 0, handleInfo->componentId, *response);
+
+                    rbusProperty_Release(tmpProperties);
+                    rbusObject_Release(data);
+                }
+                else
+                {
+                    RBUSLOG_WARN("%s: getHandler not exist for %s", __FUNCTION__, event_name);
+                }
+            }
+            if(payload)
+                rbusMessage_Release(payload);
+        }
+    }
+}
+
 static int _callback_handler(char const* destination, char const* method, rbusMessage request, void* userData, rbusMessage* response, const rtMessageHeader* hdr)
 {
     rbusHandle_t handle = (rbusHandle_t)userData;
@@ -2188,6 +2310,10 @@ static int _callback_handler(char const* destination, char const* method, rbusMe
     else if(!strcmp(method, METHOD_RPC))
     {
         return _method_callback_handler (handle, request, response, hdr);
+    }
+    else if(!strcmp(method, METHOD_SUBSCRIBE) || !strcmp(method, METHOD_UNSUBSCRIBE))
+    {
+        _subscribe_callback_handler (handle, request, response, method);
     }
     else
     {
@@ -2295,12 +2421,6 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
         goto exit_error2;
     }
 
-    if((err = rbus_registerSubscribeHandler(componentName, _event_subscribe_callback_handler, tmpHandle)) != RBUSCORE_SUCCESS)
-    {
-        RBUSLOG_ERROR("%s(%s): rbus_registerSubscribeHandler error %d", __FUNCTION__, componentName, err);
-        goto exit_error3;
-    }
-
     tmpHandle->componentName = strdup(componentName);
     tmpHandle->componentId = ++sLastComponentId;
     tmpHandle->connection = rbus_getConnection();
@@ -2316,8 +2436,6 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
     RBUSLOG_INFO("%s(%s) success", __FUNCTION__, componentName);
 
     return RBUS_ERROR_SUCCESS;
-
-exit_error3:
 
     if((err = rbus_unregisterObj(componentName)) != RBUSCORE_SUCCESS)
         RBUSLOG_ERROR("%s(%s): rbus_unregisterObj error %d", __FUNCTION__, componentName, err);
@@ -3940,12 +4058,14 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
     int32_t                         interval,
     uint32_t                        duration,    
     int                             timeout,
-    rbusSubscribeAsyncRespHandler_t async)
+    rbusSubscribeAsyncRespHandler_t async,
+    bool                            publishOnSubscribe)
 {
     rbusCoreError_t coreerr;
     int providerError = RBUS_ERROR_SUCCESS;
     rbusEventSubscription_t* sub;
     rbusMessage payload = NULL;
+    rbusMessage response = NULL;
     int destNotFoundSleep = 1000; /*miliseconds*/
     int destNotFoundTimeout;
     struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
@@ -3995,7 +4115,7 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
     {
         RBUSLOG_DEBUG("%s: %s subscribing", __FUNCTION__, eventName);
 
-        coreerr = rbus_subscribeToEventTimeout(NULL, sub->eventName, _event_callback_handler, payload, sub, &providerError, destNotFoundTimeout);
+        coreerr = rbus_subscribeToEventTimeout(NULL, sub->eventName, _event_callback_handler, payload, sub, &providerError, destNotFoundTimeout, publishOnSubscribe, &response);
         
         if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE && destNotFoundTimeout > 0)
         {
@@ -4031,8 +4151,17 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
 
     if(coreerr == RBUSCORE_SUCCESS)
     {
+        int initial_value = 0;
+        
         rtVector_PushBack(handleInfo->eventSubs, sub);
 
+        if(publishOnSubscribe)
+        {
+            rbusMessage_GetInt32(response, &initial_value);
+            if(initial_value)
+                _master_event_callback_handler(NULL, eventName, response, userData);
+            rbusMessage_Release(response);
+        }
         RBUSLOG_INFO("%s: %s subscribe retries succeeded", __FUNCTION__, eventName);
         return RBUS_ERROR_SUCCESS;
     }
@@ -4075,7 +4204,7 @@ rbusError_t  rbusEvent_Subscribe(
 
     RBUSLOG_DEBUG("%s: %s", __FUNCTION__, eventName);
 
-    errorcode = rbusEvent_SubscribeWithRetries(handle, eventName, handler, userData, NULL, 0, 0 , timeout, NULL);
+    errorcode = rbusEvent_SubscribeWithRetries(handle, eventName, handler, userData, NULL, 0, 0 , timeout, NULL, false);
 
     return errorcode;
 }
@@ -4097,7 +4226,7 @@ rbusError_t  rbusEvent_SubscribeAsync(
 
     RBUSLOG_DEBUG("%s: %s", __FUNCTION__, eventName);
 
-    errorcode = rbusEvent_SubscribeWithRetries(handle, eventName, handler, userData, NULL, 0, 0, timeout, subscribeHandler);
+    errorcode = rbusEvent_SubscribeWithRetries(handle, eventName, handler, userData, NULL, 0, 0, timeout, subscribeHandler, false);
 
     return errorcode;
 }
@@ -4179,7 +4308,7 @@ rbusError_t rbusEvent_SubscribeEx(
         //the asyncsubscribe api to handle this.
         errorcode = rbusEvent_SubscribeWithRetries(
             handle, subscription[i].eventName, subscription[i].handler, subscription[i].userData, 
-            subscription[i].filter, subscription[i].interval, subscription[i].duration, timeout, NULL);
+            subscription[i].filter, subscription[i].interval, subscription[i].duration, timeout, NULL, subscription[i].publishOnSubscribe);
 
         if(errorcode != RBUS_ERROR_SUCCESS)
         {
@@ -4217,7 +4346,7 @@ rbusError_t rbusEvent_SubscribeExAsync(
 
         errorcode = rbusEvent_SubscribeWithRetries(
             handle, subscription[i].eventName, subscription[i].handler, subscription[i].userData, 
-            subscription[i].filter, subscription[i].interval, subscription[i].duration, timeout, subscribeHandler);
+            subscription[i].filter, subscription[i].interval, subscription[i].duration, timeout, subscribeHandler, false);
 
         if(errorcode != RBUS_ERROR_SUCCESS)
         {

--- a/test/rbus/consumer/subscribeEx.c
+++ b/test/rbus/consumer/subscribeEx.c
@@ -69,8 +69,8 @@ void testSubscribeEx(rbusHandle_t handle, int* countPass, int* countFail)
     char* data[2] = { "My Data 1", "My Data2" };
 
     rbusEventSubscription_t subscriptions[2] = {
-        {"Device.TestProvider.Event1!", NULL, 0, 0, handler1, data[0], NULL, NULL},
-        {"Device.TestProvider.Event2!", NULL, 0, 0, handler2, data[1], NULL, NULL}
+        {"Device.TestProvider.Event1!", NULL, 0, 0, handler1, data[0], NULL, NULL, false},
+        {"Device.TestProvider.Event2!", NULL, 0, 0, handler2, data[1], NULL, NULL, false}
     };
 
     rc = rbusEvent_SubscribeEx(handle, subscriptions, 2, 0);

--- a/test/rbus/consumer/valueChange.c
+++ b/test/rbus/consumer/valueChange.c
@@ -354,18 +354,18 @@ void testTypesValueChange(rbusHandle_t handle)
     rbusFilter_InitRelation(&filter[11], RBUS_FILTER_OPERATOR_NOT_EQUAL, strVal);
 
     rbusEventSubscription_t subscription[12] = {
-        {"Device.TestProvider.VCParamInt0", filter[0], 0, 0, intVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamInt1", filter[1], 0, 0, intVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamInt2", filter[2], 0, 0, intVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamInt3", filter[3], 0, 0, intVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamInt4", filter[4], 0, 0, intVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamInt5", filter[5], 0, 0, intVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamStr0", filter[6], 0, 0, stringVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamStr1", filter[7], 0, 0, stringVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamStr2", filter[8], 0, 0, stringVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamStr3", filter[9], 0, 0, stringVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamStr4", filter[10], 0, 0, stringVCHandler, NULL, NULL, NULL},
-        {"Device.TestProvider.VCParamStr5", filter[11], 0, 0, stringVCHandler, NULL, NULL, NULL}
+        {"Device.TestProvider.VCParamInt0", filter[0], 0, 0, intVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamInt1", filter[1], 0, 0, intVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamInt2", filter[2], 0, 0, intVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamInt3", filter[3], 0, 0, intVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamInt4", filter[4], 0, 0, intVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamInt5", filter[5], 0, 0, intVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamStr0", filter[6], 0, 0, stringVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamStr1", filter[7], 0, 0, stringVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamStr2", filter[8], 0, 0, stringVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamStr3", filter[9], 0, 0, stringVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamStr4", filter[10], 0, 0, stringVCHandler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.VCParamStr5", filter[11], 0, 0, stringVCHandler, NULL, NULL, NULL, false}
     };
 
     rc = rbusEvent_SubscribeEx(handle, subscription, 12, 0);
@@ -528,8 +528,8 @@ void testNoAutoPubValueChange(rbusHandle_t handle)
     rbusFilter_InitRelation(&filter[1], RBUS_FILTER_OPERATOR_GREATER_THAN, intVal);
 
     rbusEventSubscription_t subscription[2] = {
-        {"Device.TestProvider.NoAutoPubInt", filter[0], 0, 0, noAutoPub1Handler, NULL, NULL, NULL},
-        {"Device.TestProvider.NoAutoPubInt", filter[1], 0, 0, noAutoPub2Handler, NULL, NULL, NULL}
+        {"Device.TestProvider.NoAutoPubInt", filter[0], 0, 0, noAutoPub1Handler, NULL, NULL, NULL, false},
+        {"Device.TestProvider.NoAutoPubInt", filter[1], 0, 0, noAutoPub2Handler, NULL, NULL, NULL, false}
     };
 
     rc = rbusEvent_SubscribeEx(handle, subscription, 2, 0);

--- a/unittests/rbus_unit_test_event_client.cpp
+++ b/unittests/rbus_unit_test_event_client.cpp
@@ -192,9 +192,9 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test1)
     printf("*********************  CREATING CLIENT : %s \n", client_name);
     conn_status = CALL_RBUS_OPEN_BROKER_CONNECTION(client_name);
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
     printf("********************Subscribed Events with Event name: event_1 in 1000 ms \n");
     conn_status = CALL_RBUS_CLOSE_BROKER_CONNECTION();
@@ -211,20 +211,20 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test2)
     conn_status = CALL_RBUS_OPEN_BROKER_CONNECTION(client_name);
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Test with invalid objname passed
-    err = rbus_subscribeToEventTimeout(NULL, "event_1", &event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(NULL, "event_1", &event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_ERROR_DESTINATION_UNREACHABLE) << "rbus_subscribeToEventTimeout failed";
     //Test with the event name  to be NULL
-    err = rbus_subscribeToEventTimeout(obj_name, "NULL", &event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "NULL", &event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_ERROR_GENERAL) << "rbus_subscribeToEventTimeout failed";
     //Test with the callback to be NULL
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",NULL, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",NULL, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     //Test with the valid Event name, objname, Callback
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
     printf("Subscribed Events with Event name: event_1 \n");
     //Test with the already subscribed Event
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
     conn_status = CALL_RBUS_CLOSE_BROKER_CONNECTION();
     ASSERT_EQ(conn_status, true) << "RBUS_CLOSE_BROKER_CONNECTION failed";
@@ -241,7 +241,7 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test3)
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Boundary Test with MAX_OBJECT_NAME_LENGTH
     memset(obj_name, 't', (sizeof(obj_name)- 1));
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     ASSERT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     conn_status = CALL_RBUS_CLOSE_BROKER_CONNECTION();
     ASSERT_EQ(conn_status, true) << "RBUS_CLOSE_BROKER_CONNECTION failed";

--- a/unittests/rbus_unit_test_event_server.cpp
+++ b/unittests/rbus_unit_test_event_server.cpp
@@ -317,19 +317,19 @@ TEST_F(EventServerAPIs, rbus_subscribeToEventTimeout_test1)
     char event_name[130] ="0";
     rbusCoreError_t err = RBUSCORE_SUCCESS;
     //Neg test subscribe before establishing connection
-    err = rbus_subscribeToEventTimeout("obj_name", "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout("obj_name", "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_STATE) << "rbus_subscribeToEventTimeout failed";
     RBUS_OPEN_BROKER_CONNECTION(client_name,RBUSCORE_SUCCESS);
     //Neg Test with more than MAX_OBJECT_NAME_LENGTH
     memset(obj_name, 't', (sizeof(obj_name)- 1));
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     //Neg Test with more than MAX_EVENT_NAME_LENGTH
     memset(event_name, 't', (sizeof(obj_name)- 1));
-    err = rbus_subscribeToEventTimeout("object_1", event_name, &event_callback, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout("object_1", event_name, &event_callback, NULL, NULL, NULL, 1000, false, NULL);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     //Neg test passing object name and callback as NULL
-    err = rbus_subscribeToEventTimeout(NULL, "event_1",NULL, NULL, NULL, NULL, 1000);
+    err = rbus_subscribeToEventTimeout(NULL, "event_1",NULL, NULL, NULL, NULL, 1000, false, NULL);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     RBUS_CLOSE_BROKER_CONNECTION(RBUSCORE_SUCCESS);
 }

--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -770,6 +770,8 @@ void event_receive_handler(rbusHandle_t handle, rbusEvent_t const* event, rbusEv
             case RBUS_EVENT_OBJECT_DELETED: stype = "RBUS_EVENT_OBJECT_DELETED";    break;
             case RBUS_EVENT_VALUE_CHANGED:  stype = "RBUS_EVENT_VALUE_CHANGED";     break;
             case RBUS_EVENT_GENERAL:        stype = "RBUS_EVENT_GENERAL";           break;
+            case RBUS_EVENT_INITIAL_VALUE:  stype = "RBUS_EVENT_INITIAL_VALUE";     break;
+            case RBUS_EVENT_INTERVAL:       stype = "RBUS_EVENT_INTERVAL";          break;
         }
 
         printf("Event received %s of type %s\n\r", event->name, stype);
@@ -1771,7 +1773,7 @@ void validate_and_execute_subscribe_cmd (int argc, char *argv[], bool add, bool 
     }
 
     runSteps = __LINE__;
-    rbusEventSubscription_t subscription = {argv[2], filter, interval, duration, event_receive_handler, userData, NULL, NULL};
+    rbusEventSubscription_t subscription = {argv[2], filter, interval, duration, event_receive_handler, userData, NULL, NULL, false};
 
     /* Async will be TRUE only when add is TRUE */
     if (isAsync && add)


### PR DESCRIPTION
Reason for change: Whenever subscribeEx is called with PublishOnSubscribe set(new element added to rbusEventSubscription_t structure), we will publish the initial value of the data model as soon as the subscription is sent. The data is sent in the below format
For property/event:
{"initialValue": data model value at time of subscription} 
Ex: {"initialValue": 123}
For Table:
{"numberOfEntries": row count, "path1": path1 name, "path2": path2 name, "path3":path3 name}
Ex: {"numberOfEntries": 3, "path1": "a.1", "path2": "a.2", "path3":"a.3"}
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR gururaja_erodesriranganramlingham@comcast.com