### PR TITLE
RDKB-46238 : rbusMethodConsumer testapp crash

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -673,6 +673,8 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
         rbusMessage_SetMessage(request, payload);
     if(publishOnSubscribe)
         rbusMessage_SetInt32(request, 1); /*for publishOnSubscribe */
+    else
+        rbusMessage_SetInt32(request, 0);
 
     if(timeout_ms <= 0)
         timeout_ms = TIMEOUT_VALUE_FIRE_AND_FORGET;


### PR DESCRIPTION
Reason for change: Single outParams variable is used in the rbusMethodConsumer. Whenever rbusMethod_Invoke() is called with a method which doesn't exist in the provider side, then the outParam value is NULL. Which is getting dereferenced in rbusObject_fwrite() resulted in crash. Handled outParam in rbus when the rbuscore returns failure.
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>