### PR TITLE
RDKB-45907: The routing logic change rbus is redefined

### DIFF
--- a/src/rtmessage/rtRoutingTree.c
+++ b/src/rtmessage/rtRoutingTree.c
@@ -481,7 +481,7 @@ rtError rtRoutingTree_AddTopicRoute(rtRoutingTree rt, const char* topicPath, con
     return RT_OK;
 }
 
-void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes, int discoverall)
+void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes)
 {
     int i;
     *routes = NULL;
@@ -545,7 +545,13 @@ void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* r
         }
 #endif
     }
-    if((treeTopic->isTable) && (!discoverall))
+    if(topic[strlen(topic)-1] == '.')
+    {
+        /* If its a partial path or a table send all routes listening to sub topics */
+        *routes = treeTopic->routeList2;
+    }
+    else
+    if(treeTopic->isTable)
     {
         /* If we ended on a table, then we need an additional check.
           We allow querying a table without adding the ".{i}" suffix.
@@ -559,11 +565,6 @@ void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* r
           *routes = curlyChild->routeList;
         }
         /*if we didn't find one then we are in some error scenario so just leave route null*/
-    }
-    else if(topic[strlen(topic)-1] == '.')
-    {
-        /* If its a partial path or a table send all routes listening to sub topics */
-        *routes = treeTopic->routeList2;
     }
     else
     {

--- a/src/rtmessage/rtRoutingTree.h
+++ b/src/rtmessage/rtRoutingTree.h
@@ -154,7 +154,7 @@ typedef struct _rtRoutingTree
 void rtRoutingTree_Create(rtRoutingTree* rt);
 void rtRoutingTree_Destroy(rtRoutingTree rt);
 rtError rtRoutingTree_AddTopicRoute(rtRoutingTree rt, const char* topic, const void* route, int err_on_dup);
-void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes, int discoverall);
+void rtRoutingTree_GetTopicRoutes(rtRoutingTree rt, const char* topic, rtList* routes);
 void rtRoutingTree_GetRouteTopics(rtRoutingTree rt, const void* route, rtList* topics);
 void rtRoutingTree_RemoveRoute(rtRoutingTree rt, const void* route);
 void rtRoutingTree_RemoveTopic(rtRoutingTree rt, const char* topic);

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -549,7 +549,7 @@ rtRouted_SendMessage(rtMessageHeader * request_hdr, rtMessage message, rtConnect
 
   /*Find the route to populate control_id field.*/
   rtRouteEntry *route = NULL;
-  rtRoutingTree_GetTopicRoutes(routingTree, request_hdr->topic, &list, 0);
+  rtRoutingTree_GetTopicRoutes(routingTree, request_hdr->topic, &list);
   if(list)
   {
     rtList_GetFront(list, &item);
@@ -1146,7 +1146,7 @@ rtRouted_OnMessageDiscoverElementObjects(rtConnectedClient* sender, rtMessageHea
           rtList routes;
           rtListItem item;
           int set = 0;
-          rtRoutingTree_GetTopicRoutes(routingTree, expression, &routes, 1);
+          rtRoutingTree_GetTopicRoutes(routingTree, expression, &routes);
           if(routes)
           {
             size_t count;
@@ -1456,7 +1456,7 @@ rtRouter_DispatchMessageFromClient(rtConnectedClient* clnt)
   START_TRACKING();
 dispatch:
 
-  rtRoutingTree_GetTopicRoutes(routingTree, clnt->header.topic, &list, 0);
+  rtRoutingTree_GetTopicRoutes(routingTree, clnt->header.topic, &list);
   if(list)
   {
     rtList_GetFront(list, &item);


### PR DESCRIPTION
Reason for change: Revert "RDKB-45652: Can't find destination component for multiple parameters (rdkcentral#39)"
This reverts commit 6950243
Revert "if else alignment change for better readability (rdkcentral#34)" This reverts commit 449f1c7
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>