### PR TITLE
RDKB-45942: Provider Crashed with Active Subscription is not publishing after restart

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1013,6 +1013,8 @@ static void registerTableRow (rbusHandle_t handle, elementNode* tableInstElem, c
         {
             RBUSLOG_WARN("failed to publish ObjectCreated event err:%d", respub);
         }
+        if(handleInfo->subscriptions)
+            rbusSubscriptions_getSubscriptionList(handle, handleInfo->subscriptions, rowElem);
 
         rbusValue_Release(rowNameVal);
         rbusValue_Release(instNumVal);

--- a/src/rbus/rbus_subscriptions.h
+++ b/src/rbus/rbus_subscriptions.h
@@ -63,6 +63,7 @@ rbusSubscription_t* rbusSubscriptions_getSubscription(rbusSubscriptions_t subscr
 /*remove an existing subscription*/
 void rbusSubscriptions_removeSubscription(rbusSubscriptions_t subscriptions, rbusSubscription_t* sub);
 
+void rbusSubscriptions_getSubscriptionList(rbusHandle_t handle, rbusSubscriptions_t subscriptions, elementNode* node);
 /*call right after a new row is added*/
 void rbusSubscriptions_onTableRowAdded(rbusSubscriptions_t subscriptions, elementNode* node);
 


### PR DESCRIPTION
Reason for change: Implement provider side resubscribing of subscriptions that are recovered if provider restarts due to crash Test Procedure: Tested and verified
Risks: Medium
Priority: P1