### PR TITLE
RDKB-46420 RDKB-46368 : Memory leak on Testapp and OneWifi

### DIFF
--- a/sampleapps/consumer/rbusTableConsumer.c
+++ b/sampleapps/consumer/rbusTableConsumer.c
@@ -216,11 +216,6 @@ int main(int argc, char *argv[])
         sleep(additionalWaitTime);
     }
 
-    printf("########################## remove colors ###############################\n");
-    rbusTable_removeRow(handle, "Device.Tables1.T1.[colors].");
-    printf("########################## remove shapes ###############################\n");
-    snprintf(name, RBUS_MAX_NAME_LENGTH, "Device.Tables1.T1.%d", instShapes);
-    rbusTable_removeRow(handle,name);
     sleep(1);
     printf("########################## unsubscribing ###############################\n");
 

--- a/sampleapps/provider/rbusEventProvider.c
+++ b/sampleapps/provider/rbusEventProvider.c
@@ -56,6 +56,10 @@ rbusError_t eventSubHandler(rbusHandle_t handle, rbusEventSubAction_t action, co
     {
         subscribed2 = action == RBUS_EVENT_ACTION_SUBSCRIBE ? 1 : 0;
     }
+    else if(!strcmp("Device.Provider1.Prop1", eventName))
+    {
+        subscribed2 = action == RBUS_EVENT_ACTION_SUBSCRIBE ? 1 : 0;
+    }
     else
     {
         printf("provider: eventSubHandler unexpected eventName %s\n", eventName);

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -711,7 +711,7 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
         }
         if(response != NULL)
             *response = internal_response;
-        if(!activate)
+        if((response == NULL) && !activate)
             rbusMessage_Release(internal_response);
     }
     else if(RBUSCORE_ERROR_DESTINATION_UNREACHABLE == ret)

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4203,8 +4203,9 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
             rbusMessage_GetInt32(response, &initial_value);
             if(initial_value)
                 _master_event_callback_handler(NULL, eventName, response, userData);
-            rbusMessage_Release(response);
         }
+        if(response)
+            rbusMessage_Release(response);
         RBUSLOG_INFO("%s: %s subscribe retries succeeded", __FUNCTION__, eventName);
         return RBUS_ERROR_SUCCESS;
     }


### PR DESCRIPTION
Reason for change: Fixed the memory leak issue reported while testing with testapp
This also should fix the OneWifi memory leak as both the valgrind result points 
to the same location
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR gururaja_erodesriranganramlingham@comcast.com