### PR TITLE
RDKB-45777: Do not use the rbusHandle for printing component name

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4805,7 +4805,7 @@ rbusError_t rbus_createSession(rbusHandle_t handle, uint32_t *pSessionId)
             rbusMessage_GetInt32(response, /*MESSAGE_FIELD_RESULT,*/ (int*) &err);
             if(RBUSCORE_SUCCESS != err)
             {
-                RBUSLOG_ERROR("Session manager reports internal error %d from %s for the object %s", err, handle->componentName, RBUS_SMGR_DESTINATION_NAME);
+                RBUSLOG_ERROR("Session manager reports internal error %d for the object %s", err, RBUS_SMGR_DESTINATION_NAME);
                 rc = RBUS_ERROR_SESSION_ALREADY_EXIST;
             }
             else


### PR DESCRIPTION
Reason for change: The CCSP component is passing CCSP BusHandle as input while requesting sessionid by CcspBaseIf_requestSessionID and in RBUS internally it de-reference it as rbusHandle to print the component name which leads to crash. Passing different handle is the problem. CCSP must be fixed; But rbus doesn't need handle to create a session, so the crash is avoided in rbus.

Test Procedure: Tested and verified

Risks: Medium
Priority: P1