### PR TITLE
RDKB-46268 Random segmentation fault occurring while running rbusTestConsumer app

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4457,7 +4457,7 @@ rbusError_t rbusEvent_UnsubscribeEx(
 
             if(coreerr != RBUSCORE_SUCCESS)
             {
-                RBUSLOG_INFO("%s: %s failed with core err=%d", __FUNCTION__, sub->eventName, coreerr);
+                RBUSLOG_INFO("%s: failed with core err=%d", __FUNCTION__, coreerr);
                 
                 //FIXME -- we just overwrite any existing error that might have happened in a previous loop
                 if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE)


### PR DESCRIPTION
RDKB-46268 Random segmentation fault occurring while running rbusTestConsumer app

Reason for change: Observed Segmentation fault when ran rbusTestConsumer app on Ubuntu 21.10. Test Procedure: Build rbus on Ubuntu 21.10, run rnusTestProvider and rbusTestConsumer -a with gdb and bt Risks: Med
Priority: P1

Signed-off-by: Deepak <deepak_m@comcast.com>