### PR TITLE
RBUS - Support for duration based subscription

### DIFF
--- a/include/rbus.h
+++ b/include/rbus.h
@@ -204,16 +204,13 @@ typedef enum
  */
 typedef enum
 {
-    RBUS_EVENT_OBJECT_CREATED, /**< Notification that an object instance 
-                                    was created in table. */
-    RBUS_EVENT_OBJECT_DELETED, /**< Notification that an object instance
-                                    was deleted in table. */
-    RBUS_EVENT_VALUE_CHANGED,  /**< Notification that a property value
-                                    was changed. */
-    RBUS_EVENT_GENERAL,        /**< Provider defined event.*/
-    RBUS_EVENT_INITIAL_VALUE,  /**< Notification of initial value immediately
-                                    after subscription*/
-    RBUS_EVENT_INTERVAL,       /**< For event with interval*/
+    RBUS_EVENT_OBJECT_CREATED,   /**< Notification that an object instance was created in table. */
+    RBUS_EVENT_OBJECT_DELETED,   /**< Notification that an object instance was deleted in table. */
+    RBUS_EVENT_VALUE_CHANGED,    /**< Notification that a property value was changed. */
+    RBUS_EVENT_GENERAL,          /**< Provider defined event.*/
+    RBUS_EVENT_INITIAL_VALUE,    /**< Notification of initial value immediately after subscription*/
+    RBUS_EVENT_INTERVAL,         /**< For event with interval*/
+    RBUS_EVENT_DURATION_COMPLETE /**< For event with duration timeout*/
 } rbusEventType_t;
 
 /**


### PR DESCRIPTION
RDKB-46586 : RBUS - Support for duration based subscription
Reason for change: Added support for passing duration while
    subscribing in RBUS and rbuscli support.
Test Procedure: 
```
1. Run rbusIntervalProvider/rbusIntervalConsumer sample apps for both interval and duration support
2. run rbuscli -i in two different terminals
- [ Terminal 1] [Provider]
   -> reg prop a.b.c 
   -> set a.b.c int 29
- [ Terminal 2] [Consumer]
   -> subint a.b.c 10 60 true
```                          
Risks: Medium
Priority: P1
Signed-off-by: Netaji Panigrahi <Netaji_Panigrahi@comcast.com>