### PR TITLE
RDKB-44710 RBUS Auto gen script context helper API wrong Implementation

### DIFF
--- a/src/rtmessage/rtHashMap.c
+++ b/src/rtmessage/rtHashMap.c
@@ -28,14 +28,6 @@
 #define RTHASHMAP_LOAD_FACTOR 0.75f
 #define RBUS_MAX_NAME_LENGTH 256
 
-typedef struct rtHashMapNode
-{
-    const void* key;
-    const void* value;
-    uint32_t lastTblIndex;
-    rtHashMap hashmap;
-} rtHashMapNode;
-
 struct _rtHashMap 
 {
     rtVector buckets;
@@ -222,27 +214,8 @@ static void rtHashMap_Resize(rtHashMap hashmap, int grow)
     rtLog_Debug("Hashmap resize %zu", rtVector_Size(hashmap->buckets));
 }
 
-int GetRowIndex(char const* path)
-{
-    int x=0;
-    char *p= NULL;
-    char buff[RBUS_MAX_NAME_LENGTH]={0} ;
-    snprintf(buff,RBUS_MAX_NAME_LENGTH,"%s", path);
-    if(buff[strlen(buff)-1] == '.'){
-        buff[strlen(buff)-1] = '\0';
-     }
-     p= (char*)buff + strlen((char*)buff);
-    while(p > buff && *(p-1) != '.')
-        p--;
-
-    x =atoi(p);
-    return x;
-}
-
 void rtHashMap_Set(rtHashMap hashmap, const void* key, const void* value)
 {
-    int keyIndex = GetRowIndex(key);
-
     rtVector bucket = rtHashMap_GetBucket(hashmap, key);
     rtHashMapNode* node = rtVector_Find(bucket, key, rtHashMap_Compare_Node);
     if(node)
@@ -260,7 +233,6 @@ void rtHashMap_Set(rtHashMap hashmap, const void* key, const void* value)
         }
         node = rt_try_malloc(sizeof(struct rtHashMapNode));
         node->hashmap = hashmap;
-        node->lastTblIndex =  (uint32_t)keyIndex;
         rtVector_PushBack(bucket, node);
         hashmap->size++;
     }
@@ -282,15 +254,10 @@ size_t rtHashMap_Get_rtVector_Size(rtHashMap hashmap)
   return rtVector_Size(hashmap->buckets);
 }
 
-int rtHashMap_GetByIndex(rtHashMap hashmap, const void* key)
+rtHashMapNode* rtHashMap_GetByIndex(rtHashMap hashmap, const void* key)
 {
-    int ret = 0;
     rtHashMapNode* node = rtVector_GetItemByCompare(rtHashMap_GetBucket(hashmap, key), key, rtHashMap_Compare_Node);
-    if (node)
-    {
-        ret = node->lastTblIndex;
-    }
-   return ret;
+    return node;
 }
 size_t rtHashMap_GetSize(rtHashMap hashmap)
 {

--- a/src/rtmessage/rtHashMap.h
+++ b/src/rtmessage/rtHashMap.h
@@ -31,6 +31,13 @@ extern "C" {
 struct _rtHashMap;
 typedef struct _rtHashMap* rtHashMap;
 
+typedef struct rtHashMapNode
+{
+    const void* key;
+    const void* value;
+    rtHashMap hashmap;
+} rtHashMapNode;
+
 typedef uint32_t (*rtHashMap_Hash_Func)(rtHashMap, const void*);
 typedef int (*rtHashMap_Compare_Func)(const void *, const void *);
 typedef const void* (*rtHashMap_Copy_Func)(const void *);
@@ -49,8 +56,7 @@ void rtHashMap_CreateEx(
 void rtHashMap_Destroy(rtHashMap hashmap);
 void rtHashMap_Set(rtHashMap hashmap, const void* key, const void* value);
 void* rtHashMap_Get(rtHashMap hashmap, const void* key);
-int rtHashMap_GetByIndex(rtHashMap hashmap, const void* key);
-int GetRowIndex(char const* path);
+rtHashMapNode* rtHashMap_GetByIndex(rtHashMap hashmap, const void* key);
 size_t rtHashMap_Get_rtVector_Size(rtHashMap hashmap);
 size_t rtHashMap_GetSize(rtHashMap hashmap);
 int rtHashMap_Contains(rtHashMap hashmap, const void* key);

--- a/src/rtmessage/rtHashMap.h
+++ b/src/rtmessage/rtHashMap.h
@@ -49,6 +49,9 @@ void rtHashMap_CreateEx(
 void rtHashMap_Destroy(rtHashMap hashmap);
 void rtHashMap_Set(rtHashMap hashmap, const void* key, const void* value);
 void* rtHashMap_Get(rtHashMap hashmap, const void* key);
+int rtHashMap_GetByIndex(rtHashMap hashmap, const void* key);
+int GetRowIndex(char const* path);
+size_t rtHashMap_Get_rtVector_Size(rtHashMap hashmap);
 size_t rtHashMap_GetSize(rtHashMap hashmap);
 int rtHashMap_Contains(rtHashMap hashmap, const void* key);
 int rtHashMap_Remove(rtHashMap hashmap, const void* key);

--- a/src/rtmessage/rtVector.c
+++ b/src/rtmessage/rtVector.c
@@ -123,6 +123,21 @@ rtVector_RemoveItem(rtVector v, void* item, rtVector_Cleanup destroyer)
   return RT_OK;
 }
 
+void*
+rtVector_GetItemByCompare(rtVector v, const void* comparison, rtVector_Compare compare)
+{
+  size_t i;
+  void* vData=NULL;
+  for (i = 0; i < v->count; ++i)
+  {
+    if (compare(v->data[i], comparison) == 0)
+    {
+        vData =  v->data[i];
+    }
+  }
+  return vData;
+}
+
 rtError 
 rtVector_RemoveItemByCompare(rtVector v, const void* comparison, rtVector_Compare compare, rtVector_Cleanup destroyer)
 {

--- a/src/rtmessage/rtVector.h
+++ b/src/rtmessage/rtVector.h
@@ -39,6 +39,7 @@ rtError rtVector_Destroy(rtVector v, rtVector_Cleanup destroyer);
 rtError rtVector_PushBack(rtVector v, void* item);
 rtError rtVector_RemoveItem(rtVector v, void* item, rtVector_Cleanup destroyer);
 rtError rtVector_RemoveItemByCompare(rtVector v, const void* comparison, rtVector_Compare compare, rtVector_Cleanup destroyer);
+void* rtVector_GetItemByCompare(rtVector v, const void* comparison, rtVector_Compare compare);
 void*   rtVector_At(rtVector v, size_t index);
 size_t  rtVector_Size(rtVector v);
 int     rtVector_HasItem(rtVector v, const void* comparison, rtVector_Compare compare);

--- a/utils/codegen/ccsp_style_generator/sampleapp/Sample_dm.xml
+++ b/utils/codegen/ccsp_style_generator/sampleapp/Sample_dm.xml
@@ -120,6 +120,54 @@
                         <writable>true</writable>
                     </parameter>
                 </parameters>
+                <objects>
+                      <object>
+                        <name>WritableTable2</name>
+			    <objectType>writableTable</objectType>
+			    <maxInstance>10</maxInstance>
+			    <functions>
+				    <func_AddEntry>WritableTable2_AddEntry</func_AddEntry>
+				    <func_DelEntry>WritableTable2_DelEntry</func_DelEntry>
+				    <func_GetParamBoolValue>WritableTable2_GetParamBoolValue</func_GetParamBoolValue>
+				    <func_SetParamBoolValue>WritableTable2_SetParamBoolValue</func_SetParamBoolValue>
+				    <func_GetParamIntValue>WritableTable2_GetParamIntValue</func_GetParamIntValue>
+				    <func_SetParamIntValue>WritableTable2_SetParamIntValue</func_SetParamIntValue>
+				    <func_GetParamUlongValue>WritableTable2_GetParamUlongValue</func_GetParamUlongValue>
+				    <func_SetParamUlongValue>WritableTable2_SetParamUlongValue</func_SetParamUlongValue>
+				    <func_GetParamStringValue>WritableTable2_GetParamStringValue</func_GetParamStringValue>
+				    <func_SetParamStringValue>WritableTable2_SetParamStringValue</func_SetParamStringValue>
+				    <func_Validate>WritableTable2_Validate</func_Validate>
+				    <func_Commit>WritableTable2_Commit</func_Commit>
+				    <func_Rollback>WritableTable2_Rollback</func_Rollback>
+			    </functions>
+			    <parameters>
+				    <parameter>
+					    <name>BoolParam2</name>
+					    <type>boolean</type>
+					    <syntax>bool</syntax>
+					    <writable>true</writable>
+				    </parameter>
+				    <parameter>
+					    <name>IntParam2</name>
+					    <type>int</type>
+					    <syntax>int</syntax>
+					    <writable>true</writable>
+				    </parameter>
+				    <parameter>
+					    <name>UlongParam2</name>
+					    <type>unsignedInt</type>
+					    <syntax>uint32</syntax>
+					    <writable>true</writable>
+				    </parameter>
+				    <parameter>
+					    <name>StringParam2</name>
+					    <type>string(256)</type>
+					    <syntax>string</syntax>
+					    <writable>true</writable>
+				    </parameter>
+			    </parameters>
+                      </object>
+                </objects>
             </object>
             <!-- Example static table -->
             <object>

--- a/utils/codegen/ccsp_style_generator/sampleapp/Sample_dm.xml
+++ b/utils/codegen/ccsp_style_generator/sampleapp/Sample_dm.xml
@@ -168,6 +168,54 @@
 			    </parameters>
                       </object>
                 </objects>
+                <objects>
+                      <object>
+                        <name>WritableTable3</name>
+			    <objectType>writableTable</objectType>
+			    <maxInstance>10</maxInstance>
+			    <functions>
+				    <func_AddEntry>WritableTable3_AddEntry</func_AddEntry>
+				    <func_DelEntry>WritableTable3_DelEntry</func_DelEntry>
+				    <func_GetParamBoolValue>WritableTable3_GetParamBoolValue</func_GetParamBoolValue>
+				    <func_SetParamBoolValue>WritableTable3_SetParamBoolValue</func_SetParamBoolValue>
+				    <func_GetParamIntValue>WritableTable3_GetParamIntValue</func_GetParamIntValue>
+				    <func_SetParamIntValue>WritableTable3_SetParamIntValue</func_SetParamIntValue>
+				    <func_GetParamUlongValue>WritableTable3_GetParamUlongValue</func_GetParamUlongValue>
+				    <func_SetParamUlongValue>WritableTable3_SetParamUlongValue</func_SetParamUlongValue>
+				    <func_GetParamStringValue>WritableTable3_GetParamStringValue</func_GetParamStringValue>
+				    <func_SetParamStringValue>WritableTable3_SetParamStringValue</func_SetParamStringValue>
+				    <func_Validate>WritableTable3_Validate</func_Validate>
+				    <func_Commit>WritableTable3_Commit</func_Commit>
+				    <func_Rollback>WritableTable3_Rollback</func_Rollback>
+			    </functions>
+			    <parameters>
+				    <parameter>
+					    <name>BoolParam3</name>
+					    <type>boolean</type>
+					    <syntax>bool</syntax>
+					    <writable>true</writable>
+				    </parameter>
+				    <parameter>
+					    <name>IntParam3</name>
+					    <type>int</type>
+					    <syntax>int</syntax>
+					    <writable>true</writable>
+				    </parameter>
+				    <parameter>
+					    <name>UlongParam3</name>
+					    <type>unsignedInt</type>
+					    <syntax>uint32</syntax>
+					    <writable>true</writable>
+				    </parameter>
+				    <parameter>
+					    <name>StringParam3</name>
+					    <type>string(256)</type>
+					    <syntax>string</syntax>
+					    <writable>true</writable>
+				    </parameter>
+			    </parameters>
+                      </object>
+                </objects>
             </object>
             <!-- Example static table -->
             <object>

--- a/utils/codegen/ccsp_style_generator/sampleapp/build.sh
+++ b/utils/codegen/ccsp_style_generator/sampleapp/build.sh
@@ -19,6 +19,6 @@
 #  limitations under the License.
 #  
 
-INCS="-I./ -I../../src -I../../../../../../include/rbus -I../../../../../..//include/rtmessage"
-LIBS="-L../../../../../../lib"
-gcc $INCS $LIBS -o Sample_app Sample_app.c Sample_rbus.c Sample_hal.c ../../src/rbus_context_helpers.c -lrbus -lrbuscore -lrtMessage -lmsgpackc -g
+INCS="-I./ -I../../src -I../../../../../install/usr/include/rbus -I../../../../../install/usr/include/rtmessage"
+LIBS="-L../../../../../install/usr/lib"
+gcc $INCS $LIBS -o Sample_app Sample_app.c Sample_rbus.c Sample_hal.c ../../src/rbus_context_helpers.c -lrbus -lrbuscore -lrtMessage -lmsgpackc -lcjson -g

--- a/utils/codegen/ccsp_style_generator/sampleapp/codegen.sh
+++ b/utils/codegen/ccsp_style_generator/sampleapp/codegen.sh
@@ -21,9 +21,9 @@
 
 APPNAME=Sample
 XML="../Sample_dm.xml"
-RBUS_INSTALL_DIR=../../../../../../
-INCS="-I./ -I../../src -I$RBUS_INSTALL_DIR/include/rbus -I$RBUS_INSTALL_DIR/include/rtmessage"
-LIBS="-L$RBUS_INSTALL_DIR/lib"
+RBUS_INSTALL_DIR=../../../../../install/
+INCS="-I./ -I../../src -I$RBUS_INSTALL_DIR/usr/include/rbus -I$RBUS_INSTALL_DIR/usr/include/rtmessage -I$RBUS_INSTALL_DIR/usr/include/"
+LIBS="-L$RBUS_INSTALL_DIR/usr/lib -lcjson"
 BUILD_SCRIPT="../../scripts/rbus_code_generator_ccsp_style.sh"
 PYTHON_SCRIPT="../../scripts/rbus_code_generator_ccsp_style.py"
 

--- a/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
+++ b/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
@@ -117,17 +117,39 @@ void* GetRowContext(char const* path)
     return rtHashMap_Get(gContextMaps.row, path);
 }
 
+int GetRowIndex(char const* path)
+{
+    int x=0;
+    char *p= NULL;
+    char buff[RBUS_MAX_NAME_LENGTH]={0} ;
+    snprintf(buff,RBUS_MAX_NAME_LENGTH,"%s", path);
+    if(buff[strlen(buff)-1] == '.'){
+        buff[strlen(buff)-1] = '\0';
+    }
+    p= (char*)buff + strlen((char*)buff);
+    while(p > buff && *(p-1) != '.')
+        p--;
+
+    x =atoi(p);
+    return x;
+}
 
 void GetRowContextInstNum(char const* tableName, uint32_t* instNum)
 {
     char rowName[RBUS_MAX_NAME_LENGTH]="";
     int temp=0;
+    int ret=0;
     while (*instNum < rtHashMap_Get_rtVector_Size(gContextMaps.row))
     {
         sprintf(rowName, "%s%u", ConvertPath(tableName), *instNum);
-        int ret = rtHashMap_GetByIndex(gContextMaps.row, ConvertPath(rowName));
-        if (ret)
-            temp = ret;
+        rtHashMapNode* node = rtHashMap_GetByIndex(gContextMaps.row, ConvertPath(rowName));
+        if(node)
+        {
+           const void* key = node->key;
+           ret = GetRowIndex(key);
+           if (ret)
+               temp = ret;
+        }
         *instNum = *instNum+1;
     }
     *instNum = temp;

--- a/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
+++ b/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
@@ -117,6 +117,22 @@ void* GetRowContext(char const* path)
     return rtHashMap_Get(gContextMaps.row, path);
 }
 
+
+void GetRowContextInstNum(char const* tableName, uint32_t* instNum)
+{
+    char rowName[RBUS_MAX_NAME_LENGTH]="";
+    int temp=0;
+    while (*instNum < rtHashMap_Get_rtVector_Size(gContextMaps.row))
+    {
+        sprintf(rowName, "%s%u", ConvertPath(tableName), *instNum);
+        int ret = rtHashMap_GetByIndex(gContextMaps.row, ConvertPath(rowName));
+        if (ret)
+            temp = ret;
+        *instNum = *instNum+1;
+    }
+    *instNum = temp;
+}
+
 void SetRowContext(char const* tableName, uint32_t instNum, char const* alias, void* context)
 {
     char path[RBUS_MAX_NAME_LENGTH];

--- a/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
+++ b/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
@@ -139,21 +139,24 @@ void GetRowContextInstNum(char const* tableName, uint32_t* instNum)
     char rowName[RBUS_MAX_NAME_LENGTH]="";
     uint32_t temp=0;
     uint32_t ret=0;
-    *instNum=0;
-    while (*instNum < rtHashMap_Get_rtVector_Size(gContextMaps.row))
+    if(instNum)
     {
-        sprintf(rowName, "%s%u", ConvertPath(tableName), *instNum);
-        rtHashMapNode* node = rtHashMap_GetByIndex(gContextMaps.row, ConvertPath(rowName));
-        if(node)
+        *instNum=0;
+        while (*instNum < rtHashMap_Get_rtVector_Size(gContextMaps.row))
         {
-           const void* key = node->key;
-           ret = GetRowIndex(key);
-           if (ret)
-               temp = ret;
+            sprintf(rowName, "%s%u", ConvertPath(tableName), *instNum);
+            rtHashMapNode* node = rtHashMap_GetByIndex(gContextMaps.row, ConvertPath(rowName));
+            if(node)
+            {
+                const void* key = node->key;
+                ret = GetRowIndex(key);
+                if (ret)
+                    temp = ret;
+            }
+            *instNum = *instNum+1;
         }
-        *instNum = *instNum+1;
+        *instNum = temp;
     }
-    *instNum = temp;
 }
 
 void SetRowContext(char const* tableName, uint32_t instNum, char const* alias, void* context)

--- a/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
+++ b/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.c
@@ -137,8 +137,9 @@ int GetRowIndex(char const* path)
 void GetRowContextInstNum(char const* tableName, uint32_t* instNum)
 {
     char rowName[RBUS_MAX_NAME_LENGTH]="";
-    int temp=0;
-    int ret=0;
+    uint32_t temp=0;
+    uint32_t ret=0;
+    *instNum=0;
     while (*instNum < rtHashMap_Get_rtVector_Size(gContextMaps.row))
     {
         sprintf(rowName, "%s%u", ConvertPath(tableName), *instNum);

--- a/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.h
+++ b/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.h
@@ -62,6 +62,13 @@ void* GetParentContext(char const* path);
  */
 void* GetRowContext(char const* path);
 
+/* void GetRowContextInstNum(char const* tableName, uint32_t* instNum)
+ * @brief      Get the instance number of row if writable table row exists
+ * @param      tableName        The path to the table name for the row to be added
+ * @param      instNum          Argument returns the current table index number to set next index
+ */
+void GetRowContextInstNum(char const* tableName, uint32_t* instNum);
+
 /* void SetRowContext(char const* tableName, uint32_t instNum, char const* alias, void* context)
  *  @brief      Set the context for a newly created row along with its instance number and any alias it might have
  *  @param      tableName       The path to the table the row was created in

--- a/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.h
+++ b/utils/codegen/ccsp_style_generator/src/rbus_context_helpers.h
@@ -62,6 +62,12 @@ void* GetParentContext(char const* path);
  */
 void* GetRowContext(char const* path);
 
+/* int GetRowIndex(char const* path)
+ * @brief      Get the instance number of row from node->key value of a writable table
+ * @param      path        The path to the writable table full name
+ */
+int GetRowIndex(char const* path);
+
 /* void GetRowContextInstNum(char const* tableName, uint32_t* instNum)
  * @brief      Get the instance number of row if writable table row exists
  * @param      tableName        The path to the table name for the row to be added


### PR DESCRIPTION
RDKB-44710 RBUS Auto gen script context helper API wrong Implementation
Reason for change: Implemented Support for Nested Writable Table for Sample_app Test Procedure: 1.run Rtrouted(Terminal 1); rbuscli -i (term2); build and run Sample_app (Term3),
                2.Term2- add Device.Sample.WritableTable.  (repeat to add more parent table index i={1,2,3 ....})
		3.Term2- add Device.Sample.WritableTable.{i}.WritableTable2.{j} (nested table, repeat to add more child indexes j={1,2,3,...} for each parent index above)
		4.Term2 -set nested table parameters-StringParam2;UlongParam2;IntParam2;BoolParam2; ex: set Device.Sample.WritableTable.3.WritableTable2.3.StringParam2 string Deepak323
		5.Term2- get Device.Sample.WritableTable.{i}.WritableTable2.{j}.{Param} and verify set values
		6.Term2- del Device.Sample.WritableTable.{i}.WritableTable2.{j}. or Device.Sample.WritableTable.{i}. and get and verify if row is deleted
		7.Term2- Add Device.Sample.WritableTable.{i}.WritableTable2.{j}. should add from last index {j}=last-J index +1.
Risks: Med
Priority: P1

Signed-off-by: Deepak <deepak_m@comcast.com>