### PR TITLE
RDKB-46634 Rbus build warnings from src folder needs fix on Ubuntu-22.10

### DIFF
--- a/src/rtmessage/rtError.c
+++ b/src/rtmessage/rtError.c
@@ -122,7 +122,7 @@ const char* rtStrError_SystemError(int e)
   // TODO: The below #ifdef is not the best approach. @see man strerror_r and
   // /usr/include/string.h for proper check of which version of strerror_r is 
   // available. Need to check for osx portability also
-  if (specific && specific->error_message)
+  if (specific)
   {
     #ifdef __linux__
     int n = strerror_r(e, specific->error_message, 256);

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -960,7 +960,7 @@ rtRouted_OnMessageDiscoverRegisteredComponents(rtConnectedClient* sender, rtMess
           for (i = 0; i < rtVector_Size(routes); i++)
           {
               rtRouteEntry* route = (rtRouteEntry *) rtVector_At(routes, i);
-              if((route->expression != NULL) && (strcmp(route->expression, "")) && ('_' != route->expression[0]))
+              if((route) && (strcmp(route->expression, "")) && ('_' != route->expression[0]))
               {
                   if(pass == 0)
                       counter++;

--- a/test/rbus/provider/rbusTestProvider.c
+++ b/test/rbus/provider/rbusTestProvider.c
@@ -311,9 +311,9 @@ rbusError_t createTableRowNode(Node* parent, char const* alias, uint32_t* instNu
 
             assert(child->type == RBUS_ELEMENT_TYPE_TABLE_ROW);
 
-            if(child->type == RBUS_ELEMENT_TYPE_TABLE_ROW)
+            if(child && child->type == RBUS_ELEMENT_TYPE_TABLE_ROW)
             {
-                if(child->name && strlen(child->name) && strcmp(child->name, alias)==0)
+                if(strlen(child->name) && strcmp(child->name, alias)==0)
                 {
                     return RBUS_ERROR_ELEMENT_NAME_DUPLICATE;
                 }

--- a/test/rbus/provider/rbusTestProvider.c
+++ b/test/rbus/provider/rbusTestProvider.c
@@ -309,7 +309,7 @@ rbusError_t createTableRowNode(Node* parent, char const* alias, uint32_t* instNu
 
             rtListItem_GetData(item, (void**)&child);
 
-            assert(child && child->type == RBUS_ELEMENT_TYPE_TABLE_ROW);
+            assert(child);
 
             if(child->type == RBUS_ELEMENT_TYPE_TABLE_ROW)
             {

--- a/test/rbus/provider/rbusTestProvider.c
+++ b/test/rbus/provider/rbusTestProvider.c
@@ -309,9 +309,9 @@ rbusError_t createTableRowNode(Node* parent, char const* alias, uint32_t* instNu
 
             rtListItem_GetData(item, (void**)&child);
 
-            assert(child->type == RBUS_ELEMENT_TYPE_TABLE_ROW);
+            assert(child && child->type == RBUS_ELEMENT_TYPE_TABLE_ROW);
 
-            if(child && child->type == RBUS_ELEMENT_TYPE_TABLE_ROW)
+            if(child->type == RBUS_ELEMENT_TYPE_TABLE_ROW)
             {
                 if(strlen(child->name) && strcmp(child->name, alias)==0)
                 {


### PR DESCRIPTION
RDKB-46634 Rbus build warnings from src folder needs fix on Ubuntu-22.10 ver

Reason for change: three Build Warning (-Waddress) observed while compiling RBus files rtError.c rtrouted.c in src/ and rbusTestProvider.c in test/ folder on Ubuntu 22.10 Test Procedure: Build rbus on Ubuntu 21.10.
Risks: Med
Priority: P2

Signed-off-by: Deepak <deepak_m@comcast.com>