### PR TITLE
RDKB-46554: Memory leak in EventClientAPIs.rbus_subscribeToEventTimeout_test1

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -714,7 +714,7 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
         }
         if(response != NULL)
             *response = internal_response;
-        if((response == NULL) && !activate)
+        else
             rbusMessage_Release(internal_response);
     }
     else if(RBUSCORE_ERROR_DESTINATION_UNREACHABLE == ret)


### PR DESCRIPTION
Reason for change: Fixed memory leak issue
Test Procedure: Test and verified with valgrind
Risks: Low