### PR TITLE
RDKB-46677: Provider Crashed with Active Subscription of event with aliasName is not publishing after restart

### DIFF
--- a/src/rbus/rbus_subscriptions.c
+++ b/src/rbus/rbus_subscriptions.c
@@ -132,7 +132,7 @@ rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscr
     sub = rt_malloc(sizeof(rbusSubscription_t));
 
     sub->listener = strdup(listener);
-    sub->eventName = strdup(eventName);
+    sub->eventName = strdup(registryElem->fullName);
     sub->componentId = componentId;
     sub->filter = filter;
     if(sub->filter)


### PR DESCRIPTION
Reason for change: Implement provider side resubscribing of subscriptions of event with aliasName that are recovered if provider restarts due to crash 
Test Procedure: Tested and verified
Risks: Medium
Priority: P1