### PR TITLE
RDKB-45777: Sample code for rbus_session_mgr

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -114,11 +114,13 @@ else ()
     target_link_libraries(rbus_gtest.bin rbus gtest gcov)
 endif()
 
-install (TARGETS rbus_event_server 
-    rbus_test_server 
-    rbus_gtest.bin 
-    sample_rbus_session_mgr
+install (TARGETS rbus_event_server rbus_test_server rbus_gtest.bin
     RUNTIME DESTINATION bin)
+
+if (BUILD_SESSIONMGR_SAMPLE_APPS)
+    install (TARGETS sample_rbus_session_mgr
+        RUNTIME DESTINATION bin)
+endif (BUILD_SESSIONMGR_SAMPLE_APPS)
 
 if (ENABLE_CODE_COVERAGE)
     install(CODE "execute_process(COMMAND find . -name *.gcno -exec tar -rvf rbus_src_gcno.tar {} \;)")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -114,7 +114,10 @@ else ()
     target_link_libraries(rbus_gtest.bin rbus gtest gcov)
 endif()
 
-install (TARGETS rbus_event_server rbus_test_server rbus_gtest.bin sample_rbus_session_mgr
+install (TARGETS rbus_event_server 
+    rbus_test_server 
+    rbus_gtest.bin 
+    sample_rbus_session_mgr
     RUNTIME DESTINATION bin)
 
 if (ENABLE_CODE_COVERAGE)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -73,6 +73,12 @@ add_executable(rbus_event_server rbus_test_util.c rbus_event_server.c)
 add_dependencies(rbus_event_server rbuscore)
 target_link_libraries(rbus_event_server rbuscore)
 
+if (BUILD_SESSIONMGR_SAMPLE_APPS)
+add_executable(sample_rbus_session_mgr sample_rbus_session_mgr.c)
+add_dependencies(sample_rbus_session_mgr rbus)
+target_link_libraries(sample_rbus_session_mgr rbus)
+endif (BUILD_SESSIONMGR_SAMPLE_APPS)
+
 enable_testing()
 
 add_executable(rbus_gtest.bin
@@ -108,7 +114,7 @@ else ()
     target_link_libraries(rbus_gtest.bin rbus gtest gcov)
 endif()
 
-install (TARGETS rbus_event_server rbus_test_server rbus_gtest.bin
+install (TARGETS rbus_event_server rbus_test_server rbus_gtest.bin sample_rbus_session_mgr
     RUNTIME DESTINATION bin)
 
 if (ENABLE_CODE_COVERAGE)

--- a/unittests/sample_rbus_session_mgr.c
+++ b/unittests/sample_rbus_session_mgr.c
@@ -1,0 +1,48 @@
+/*
+  * If not stated otherwise in this file or this component's Licenses.txt file
+  * the following copyright and licenses apply:
+  *
+  * Copyright 2016 RDK Management
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <rbus.h>
+#include "rbuscore.h"
+#include "rbus_session_mgr.h"
+#include "rtLog.h"
+
+
+int main(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+    rtLog_SetLevel(RT_LOG_INFO);
+
+    rbusHandle_t handle = NULL;
+    unsigned int sessionId = 0 , newSessionId = 0;
+    char *componentName = NULL;
+
+    componentName = strdup("sessiontest");
+
+    rbus_open(&handle, componentName);
+    rbus_createSession(handle, &sessionId);
+    rbus_getCurrentSession(handle, &newSessionId);
+    rbus_closeSession(handle, sessionId); 
+    rbus_close(handle);
+
+    return 0;
+}


### PR DESCRIPTION
Reason for change: For testing functionality of rbusSession APIs 
Test Procedure: Execute command ./sample_rbus_session_mgr 
Risks: Low