### PR TITLE
Revert "RDKB-46677: Provider Crashed with Active Subscription of event with aliasName is not publishing after restart"

### DIFF
--- a/src/rbus/rbus_subscriptions.c
+++ b/src/rbus/rbus_subscriptions.c
@@ -132,7 +132,7 @@ rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscr
     sub = rt_malloc(sizeof(rbusSubscription_t));
 
     sub->listener = strdup(listener);
-    sub->eventName = strdup(registryElem->fullName);
+    sub->eventName = strdup(eventName);
     sub->componentId = componentId;
     sub->filter = filter;
     if(sub->filter)


### PR DESCRIPTION
Reverts rdkcentral/rbus#88