### PR TITLE
Ensure to to have rbusConfig created for all the rbus APIs

### DIFF
--- a/src/rbus/rbus_config.c
+++ b/src/rbus/rbus_config.c
@@ -102,7 +102,7 @@ int rbusConfig_ReadGetTimeout()
         if (timeout > 0)
             return timeout * 1000;
     }
-
+    rbusConfig_CreateOnce();
     return gConfig->getTimeout;
 }
 
@@ -123,6 +123,6 @@ int rbusConfig_ReadSetTimeout()
         if (timeout > 0)
             return timeout * 1000;
     }
-
+    rbusConfig_CreateOnce();
     return gConfig->setTimeout;
 }


### PR DESCRIPTION
Reason for change: Requesting sessionid by CcspBaseIf_requestSessionID is resulting in a crash 
Test Procedure: Tested and verified
Risks: Medium