### PR TITLE
Update rtLog.c to fix compilation warning

### DIFF
--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -237,7 +237,7 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
     char module[MODULE_BUFFER_SIZE] = {0};
     rdk_LogLevel rdklevel = rdkLogLevelFromrtLogLevel(level);
     sprintf(module, "LOG.RDK.%s", mod);
-    RDK_LOG(rdklevel, module, buff);
+    RDK_LOG(rdklevel, module, "%s", buff);
   }
 #endif
   else


### PR DESCRIPTION
Reason for change: To fix warning when ENABLE_RDKLOGGER is ON
Test Procedure: Tested and verified
Risks: Low