### PR TITLE
TCXB7-5676 - Killing of RBUS Daemon is not rebooting the device

### DIFF
--- a/conf/rbus.service
+++ b/conf/rbus.service
@@ -23,7 +23,7 @@ Description= An IPC framework
 Type=forking
 TimeoutSec=300
 ExecStart=/usr/bin/rtrouted $RTROUTER_OPTIONAL_ARGS
-ExecStop=/bin/sh -c 'echo 0 >> /tmp/rbus_stopped'
+ExecStopPost=/bin/sh -c 'echo 0 >> /tmp/rbus_stopped'
 Restart=no
 
 


### PR DESCRIPTION
Reason for change: Changed ExecStop to ExecStopPost. With which device is getting rebooted when rtrouted process is killed
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>