### PR TITLE
Segmentation fault from Func rbus_discoverObjectElements during unit …

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1902,7 +1902,8 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
         const char * value = NULL;
         char **array_ptr = NULL;
 
-        *elements = array_ptr;
+        *elements = NULL;
+
         rtMessage_GetInt32(msg, RTM_DISCOVERY_COUNT, &size);
         rtMessage_GetArrayLength(msg, RTM_DISCOVERY_ITEMS, &length);
 
@@ -1917,6 +1918,7 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
             array_ptr = (char **)rt_try_malloc(size * sizeof(char *));
             if (NULL != array_ptr)
             {
+                *elements = array_ptr;
                 memset(array_ptr, 0, (length * sizeof(char *)));
                 for (i = 0; i < length; i++)
                 {
@@ -1926,10 +1928,7 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
                             free(array_ptr[j]);
                         free(array_ptr);
                         array_ptr=NULL;
-			if(*elements == NULL)
-                            RBUSCORELOG_ERROR("DEEPAK *elements IS NULL");
-			else
-                            RBUSCORELOG_ERROR("DEEPAK *elements NOT NULL");
+			*elements = NULL;
                         RBUSCORELOG_ERROR("Read/Memory allocation failure");
                         ret = RBUSCORE_ERROR_GENERAL;
                         break;

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1900,7 +1900,9 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
     {
         int32_t size, length, i;
         const char * value = NULL;
+        char **array_ptr = NULL;
 
+        *elements = array_ptr;
         rtMessage_GetInt32(msg, RTM_DISCOVERY_COUNT, &size);
         rtMessage_GetArrayLength(msg, RTM_DISCOVERY_ITEMS, &length);
 
@@ -1909,13 +1911,12 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
             RBUSCORELOG_ERROR("rbus_GetElementsAddedByObject size missmatch");
         }
 
+        *count = size;
         if(size && length)
         {
-            char **array_ptr = (char **)rt_try_malloc(size * sizeof(char *));
-            *count = size;
+            array_ptr = (char **)rt_try_malloc(size * sizeof(char *));
             if (NULL != array_ptr)
             {
-                *elements = array_ptr;
                 memset(array_ptr, 0, (length * sizeof(char *)));
                 for (i = 0; i < length; i++)
                 {
@@ -1924,6 +1925,7 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
                         for (int j = 0; j < i; j++)
                             free(array_ptr[j]);
                         free(array_ptr);
+                        array_ptr=NULL;
                         RBUSCORELOG_ERROR("Read/Memory allocation failure");
                         ret = RBUSCORE_ERROR_GENERAL;
                         break;

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1926,6 +1926,10 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
                             free(array_ptr[j]);
                         free(array_ptr);
                         array_ptr=NULL;
+			if(*elements == NULL)
+                            RBUSCORELOG_ERROR("DEEPAK *elements IS NULL");
+			else
+                            RBUSCORELOG_ERROR("DEEPAK *elements NOT NULL");
                         RBUSCORELOG_ERROR("Read/Memory allocation failure");
                         ret = RBUSCORE_ERROR_GENERAL;
                         break;

--- a/unittests/rbus_test_util.c
+++ b/unittests/rbus_test_util.c
@@ -238,13 +238,13 @@ int handle_getLargeBinaryData(const char * destination, const char * method, rbu
     (void) method;
     (void) hdr;
     uint8_t data[1024] = {0};
-    int i = 0;
+    uint8_t i = 0;
     char chunk_name[10] = {0};
 
     rbusMessage_Init(response);
     for(i = 1; i <= binary_data_size; i++)
     {
-        snprintf(chunk_name, 10, "chunk%d", i);
+        snprintf(chunk_name, 10, "chunk%u", i);
         memset(data, (i + '0'), sizeof(data));
         rbusMessage_SetBytes(*response, data, sizeof(data));
     }

--- a/unittests/rbus_unit_stresstest_server.cpp
+++ b/unittests/rbus_unit_stresstest_server.cpp
@@ -840,7 +840,9 @@ TEST_F(StressTestServer, rbusMessage_GetElementsAddedByObject_test1)
 
         for(i = 0; i < num_objects; ++i)
             free(objects[i]);
-        free(objects);
+        if(objects != NULL){
+            free(objects);
+        }
 
         if(conn_status)
             CLOSE_BROKER_CONNECTION();

--- a/unittests/rbus_unit_stresstest_server.cpp
+++ b/unittests/rbus_unit_stresstest_server.cpp
@@ -838,9 +838,9 @@ TEST_F(StressTestServer, rbusMessage_GetElementsAddedByObject_test1)
         err = rbus_discoverObjectElements("test.", &num_objects, &objects);
         EXPECT_EQ(err, RBUSCORE_SUCCESS) << "rbusMessage_discoverObjectElements failed";
 
-        for(i = 0; i < num_objects; ++i)
-            free(objects[i]);
         if(objects != NULL){
+            for(i = 0; i < num_objects; ++i)
+                free(objects[i]);
             free(objects);
         }
 


### PR DESCRIPTION
Segmentation fault from Func rbus_discoverObjectElements during unit test, code Coverage

Reason for change: Fixed: 1Segmentation fault from Func rbus_discoverObjectElements during unit test, code Coverage. 2.build failure when compiling rbus with ENABLE_CODE_COVERAGE=ON
Test Procedure: trigger unit testing on Git Workflow and Desktop with Ubuntu 22.04 or above
Risks: Medium