### PR TITLE
Update not to trim the traceState & traceParent

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2314,18 +2314,30 @@ void rbus_setOpenTelemetryContext(const char *traceParent, const char *traceStat
 {
     rbusOpenTelemetryContext *ot_ctx = rbus_getOpenTelemetryContextFromThreadLocal();
 
-    if ((traceParent) && (strlen(traceParent) > 0))
+    if (traceParent)
     {
-        strncpy(ot_ctx->otTraceParent, traceParent, RBUS_OPEN_TELEMETRY_DATA_MAX - 1);
-        ot_ctx->otTraceParent[RBUS_OPEN_TELEMETRY_DATA_MAX - 1] = '\0';
+	size_t tpLen = strlen(traceParent);
+	if ((tpLen > 0) && (tpLen < (RBUS_OPEN_TELEMETRY_DATA_MAX - 1)))
+	{
+            strncpy(ot_ctx->otTraceParent, traceParent, tpLen);
+            ot_ctx->otTraceParent[tpLen + 1] = '\0';
+	}
+	else
+            ot_ctx->otTraceParent[0] = '\0';
     }
     else
         ot_ctx->otTraceParent[0] = '\0';
 
-    if ((traceState) && (strlen(traceState) > 0))
+    if (traceState)
     {
-        strncpy(ot_ctx->otTraceState, traceState, RBUS_OPEN_TELEMETRY_DATA_MAX - 1);
-        ot_ctx->otTraceState[RBUS_OPEN_TELEMETRY_DATA_MAX - 1] = '\0';
+        size_t tsLen = strlen(traceState);
+	if ((tsLen > 0) && (tsLen < (RBUS_OPEN_TELEMETRY_DATA_MAX - 1)))
+	{
+            strncpy(ot_ctx->otTraceState, traceState, tsLen);
+            ot_ctx->otTraceState[tsLen + 1] = '\0';
+	}
+	else
+            ot_ctx->otTraceState[0] = '\0';
     }
     else
         ot_ctx->otTraceState[0] = '\0';


### PR DESCRIPTION
Updated rbus_setOpenTelemetryContext to *not* to trim the traceState & traceParent