### PR TITLE
Setting componentName of RbusHandle to NULL in rbus_close

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2590,7 +2590,7 @@ rbusError_t rbus_close(rbusHandle_t handle)
     }
 
     componentName = handleInfo->componentName;
-
+    handleInfo->componentName=NULL;
     rbusHandleList_Remove(handleInfo);
 
     if(rbusHandleList_IsEmpty())
@@ -2635,6 +2635,7 @@ rbusError_t rbus_regDataElements(
     struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
 
     VERIFY_NULL(handleInfo);
+    VERIFY_NULL(handleInfo->componentName);
     VERIFY_NULL(elements);
     VERIFY_ZERO(numDataElements);
 


### PR DESCRIPTION
Setting componentName of RbusHandle to NULL in rbus_close

Reason for change: RbusHandle pointer to componentName was not initialized to NULL in rbus_close function. And VERIFY_NULL check for same parameter was missing in rbus_regDataElements function

Test Procedure:
1.Load the test build in device
2.Connect few clients and perform 20 rounds of reboots.
3.Check Stacktrace if any crash is seen.

Risks: Medium
Priority: P1