### PR TITLE
ARRISXB6-13231 : Observing "CcspWifiSsp" crash with signature rbus as…

### DIFF
--- a/src/rbus/rbus_asyncsubscribe.c
+++ b/src/rbus/rbus_asyncsubscribe.c
@@ -402,12 +402,17 @@ void rbusAsyncSubscribe_RemoveSubscription(rbusEventSubscription_t* subscription
 rbusEventSubscription_t* rbusAsyncSubscribe_GetSubscription(rbusHandle_t handle, char const* eventName, rbusFilter_t filter)
 {
     rbusEventSubscription_t sub = {0};
+    rbusEventSubscription_t* EventSub = {0};
+
     if(!gRetrier)
         return NULL;
     sub.handle = handle;
     sub.eventName = eventName;
     sub.filter = filter;
-    return rtList_Find(gRetrier->items, &sub, rbusAsyncSubscribeRetrier_CompareSubscription);
+    LOCK();
+    EventSub = rtList_Find(gRetrier->items, &sub, rbusAsyncSubscribeRetrier_CompareSubscription);
+    UNLOCK();
+    return EventSub;
 }
 
 void rbusAsyncSubscribe_CloseHandle(rbusHandle_t handle)


### PR DESCRIPTION
…ync call

Reason for change: Changed rbusAsyncSubscribe_GetSubscription function call to have the mutex lock around gRetrier-> items global variable Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>