### PR TITLE
RDKB-47357 [Rack][TCBR][Sprint]:Observing CcspCMAgentSsp crash signature " rtList_RemoveItem" Fingerprint : 48111963 

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -777,6 +777,7 @@ rtConnection_Destroy(rtConnection con)
     }
     rtList_Destroy(con->pending_requests_list,NULL);
     rtList_Destroy(con->callback_message_list, rtMessageInfo_ListItemFree);
+    con->pending_requests_list = NULL;
     pthread_mutex_unlock(&con->mutex);
     if(0 != found_pending_requests)
     {

--- a/src/rtmessage/rtList.c
+++ b/src/rtmessage/rtList.c
@@ -123,6 +123,7 @@ rtError rtList_Destroy(rtList list, rtList_Cleanup destroyer)
     }while(item);
   }
   free(list);
+  list = NULL;
   return RT_OK;
 }
 rtError rtList_PushFront(rtList list, void* data, rtListItem* pitem)


### PR DESCRIPTION
RDKB-47357 [Rack][TCBR][Sprint]:Observing CcspCMAgentSsp crash with signature as " rtList_RemoveItem" with Fingerprint : 48111963 during Reboot and Stability Test.

Reason for change: Observing CcspCMAgentSsp crash with signature as " rtList_RemoveItem" with Fingerprint : 48111963 during Reboot and Stability Test.
Test Procedure: Reboot Test on 20 devices
Risks: Medium
Priority: P1