### PR TITLE
RDKB-48890 Addressing Unit test work flow on Github Rdkcentral Rbus

### DIFF
--- a/test/rbus/consumer/rbusTestConsumer.c
+++ b/test/rbus/consumer/rbusTestConsumer.c
@@ -278,6 +278,8 @@ exit1:
                 testList[i].name, 
                 testList[i].countPass, 
                 testList[i].countFail);
+            if(testList[i].countFail)
+                rc = RBUS_ERROR_BUS_ERROR;
         }
     }
     printf("#                                                 #\n");


### PR DESCRIPTION
*RDKB-48890 Addressing Unit test work flow on Github Rdkcentral Rbus

Reason for change: Github unittest workflow is not capturing failure count of rbusTestConsumer
Test Procedure: Trigger and verify Unittest work flow on rdkcentral rbus github
Risks: Medium
Priority: P1