### PR TITLE
RDKB-48936 [23Q2_Sprint] Events Test Cases are Failing in rbusTestConsumer

### DIFF
--- a/src/rbus/rbus_subscriptions.c
+++ b/src/rbus/rbus_subscriptions.c
@@ -132,10 +132,7 @@ rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscr
     sub = rt_malloc(sizeof(rbusSubscription_t));
 
     sub->listener = strdup(listener);
-    if(strchr(eventName, '['))
-        sub->eventName = strdup(registryElem->fullName);
-    else
-        sub->eventName = strdup(eventName);
+    sub->eventName = strdup(eventName);
     sub->componentId = componentId;
     sub->filter = filter;
     if(sub->filter)


### PR DESCRIPTION
RDKB-48936 [23Q2_Sprint] Events Test Cases are Failing in rbusTestConsumer

Reason for change: Reverting RDKB-46677 as 32 test cases of rbusTestConsumer was failing on Github unittest
Test Procedure: Verify rbusTestConsumer on VM and Unittest work flow on rdkcentral rbus github
Risks: Medium
Priority: P1