### PR TITLE
RDKB-49347 Rbus should not allow Table Subscription if event name does not end with '.'(DOT)

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2262,6 +2262,15 @@ static void _subscribe_callback_handler (rbusHandle_t handle, rbusMessage reques
                 RBUSLOG_ERROR("%s: payload missing in subscribe request for event %s from %s", __FUNCTION__, event_name, sender);
             }
 
+            elementNode* el = NULL;
+            el = retrieveInstanceElement(handleInfo->elementRoot, event_name);
+
+            if (el !=NULL && (el->type == RBUS_ELEMENT_TYPE_TABLE)  && (event_name[strlen(event_name)-1] != '.'))
+            {
+                RBUSLOG_ERROR(":%s: Invalid event_name: %s, Element Table Subscription should end with '.'",__FUNCTION__, event_name);
+                return ;
+            }
+
             int added = strncmp(method, METHOD_SUBSCRIBE, MAX_METHOD_NAME_LENGTH) == 0 ? 1 : 0;
             if(added)
                 rbusMessage_GetInt32(request, &publishOnSubscribe);


### PR DESCRIPTION
* Rbus should not allow Table Subscription if event name does not end with '.'(DOT)

Reason for change: Subscription for event name of Table type should not be allowed if event name does not end with "." Test Procedure: 1)Rbus Rtrouted and rbusTestProvider  Or rbustableProvider; rbus rbuscli -i; sub Device.Tables1.T1 should fail and sub Device.Tables1.T1. should pass 2) Rbus Rtrouted and rbusTestProvider and rbusTestConsumer, all test cases should pass

Risks: Medium
Priority: P1