### PR TITLE
Adding support for rbuscli with -g and -s options

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -526,9 +526,13 @@ void show_menu(const char* command)
             printf ("\nUsage:\n\r");
             printf ("\trbuscli [command]\n\r");
             printf ("\trbuscli [-i]\n\r");
+            printf ("\trbuscli [-g]\n\r");
+            printf ("\trbuscli [-s]\n\r");
             printf ("\n\r");
             printf ("Options:\n\r");
             printf ("\t\e[1m-i\e[0m Run as interactive shell.\n\r");
+            printf ("\t\e[1m-g\e[0m get the parameter value \e[4mpath\e[0m [\e[4mpath\e[0m \e[4m...\e[0m]\n\r");
+            printf ("\t\e[1m-s\e[0m set the parameter value \e[4mparameter\e[0m \e[4mtype\e[0m \e[4mvalue\e[0m [[\e[4mparameter\e[0m \e[4mtype\e[0m \e[4mvalue\e[0m] \e[4m...\e[0m] [commit]\n\r");
             printf ("\n\r");
             printf ("Commands:\n\r");
         }
@@ -1240,16 +1244,22 @@ void validate_and_execute_get_cmd (int argc, char *argv[])
             rbusValueType_t type = rbusValue_GetType(val);
             char *pStrVal = rbusValue_ToString(val,NULL,0);
 
-            printf ("Parameter %2d:\n\r", i+1);
-            printf ("              Name  : %s\n\r", rbusProperty_GetName(next));
-            printf ("              Type  : %s\n\r", getDataType_toString(type));
-            printf ("              Value : %s\n\r", pStrVal);
+	    if ((strcmp("-g", argv[1]) == 0) && (!isWildCard))
+	    {
+		    printf ("%s\n\r", pStrVal);
+	    }  
+	    else
+	    {
+		    printf ("Parameter %2d:\n\r", i+1);
+		    printf ("              Name  : %s\n\r", rbusProperty_GetName(next));
+		    printf ("              Type  : %s\n\r", getDataType_toString(type));
+		    printf ("              Value : %s\n\r", pStrVal);
+	    }
+	    if(pStrVal)
+		    free(pStrVal);
 
-            if(pStrVal)
-                free(pStrVal);
-
-            next = rbusProperty_GetNext(next);
-        }
+	    next = rbusProperty_GetNext(next);
+	}
         /* Free the memory */
         rbusProperty_Release(outputVals);
     }
@@ -1341,7 +1351,7 @@ void validate_and_execute_set_cmd (int argc, char *argv[])
     if (!verify_rbus_open())
         return;
 
-    if (i > 4) /* Multiple set commands; Lets use rbusValue_t */
+    if ((i > 4) && !(strcmp("-s", argv[1]) == 0)) /* Multiple set commands; Lets use rbusValue_t */
     {
         int isInvalid = 0;
         int index = 0;
@@ -2453,11 +2463,11 @@ int handle_cmds (int argc, char *argv[])
     char* command = argv[1];
 
     runSteps = __LINE__;
-    if(matchCmd(command, 3, "getvalues"))
+    if(matchCmd(command, 3, "getvalues") || (matchCmd(command, 2, "-g") && !g_isInteractive))
     {
         validate_and_execute_get_cmd (argc, argv);
     }
-    else if(matchCmd(command, 3, "setvalues"))
+    else if(matchCmd(command, 3, "setvalues") || (matchCmd(command, 2, "-s") && !g_isInteractive))
     {
         validate_and_execute_set_cmd (argc, argv);
     }

--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -47,6 +47,8 @@
 
 static int runSteps = __LINE__;
 
+bool g_isDebug = true;
+#define RBUSCLI_LOG(...) if (g_isDebug == true) {printf(__VA_ARGS__);}
 typedef struct _tlv_t {
     char *p_name;
     char *p_type;
@@ -526,13 +528,13 @@ void show_menu(const char* command)
             printf ("\nUsage:\n\r");
             printf ("\trbuscli [command]\n\r");
             printf ("\trbuscli [-i]\n\r");
-            printf ("\trbuscli [-g]\n\r");
-            printf ("\trbuscli [-s]\n\r");
+            printf ("\trbuscli [-g \e[0m \e[4mparameter\e\e[0m \e[0m]\n\r");
+            printf ("\trbuscli [-s \e[0m \e[4mparameter\e[0m \e[4mtype\e[0m \e[4mvalue\e[0m \e[0m]\n\r");
             printf ("\n\r");
             printf ("Options:\n\r");
             printf ("\t\e[1m-i\e[0m Run as interactive shell.\n\r");
-            printf ("\t\e[1m-g\e[0m get the parameter value \e[4mpath\e[0m [\e[4mpath\e[0m \e[4m...\e[0m]\n\r");
-            printf ("\t\e[1m-s\e[0m set the parameter value \e[4mparameter\e[0m \e[4mtype\e[0m \e[4mvalue\e[0m [[\e[4mparameter\e[0m \e[4mtype\e[0m \e[4mvalue\e[0m] \e[4m...\e[0m] [commit]\n\r");
+            printf ("\t\e[1m-g\e[0m Get the value of parameter\n\r");
+            printf ("\t\e[1m-s\e[0m Set the value of parameter\n\r");
             printf ("\n\r");
             printf ("Commands:\n\r");
         }
@@ -1200,9 +1202,9 @@ void validate_and_execute_get_cmd (int argc, char *argv[])
     const char *pInputParam[RBUS_CLI_MAX_PARAM] = {0, 0};
     bool isWildCard = false;
 
-    if (numOfInputParams < 1)
+    if ((numOfInputParams < 1) || ((strcmp("-g", argv[1]) == 0) && (numOfInputParams > 1)))
     {
-        printf ("Invalid arguments. Please see the help\n\r");
+        RBUSCLI_LOG ("Invalid arguments. Please see the help\n\r");
         return;
     }
 
@@ -1247,7 +1249,7 @@ void validate_and_execute_get_cmd (int argc, char *argv[])
 	    if ((strcmp("-g", argv[1]) == 0) && (!isWildCard))
 	    {
 		    printf ("%s\n\r", pStrVal);
-	    }  
+	    }
 	    else
 	    {
 		    printf ("Parameter %2d:\n\r", i+1);
@@ -1265,7 +1267,7 @@ void validate_and_execute_get_cmd (int argc, char *argv[])
     }
     else
     {
-        printf ("Failed to get the data. Error : %d\n\r",rc);
+        RBUSCLI_LOG ("Failed to get the data. Error : %d\n\r",rc);
     }
 }
 
@@ -1342,9 +1344,9 @@ void validate_and_execute_set_cmd (int argc, char *argv[])
     runSteps = __LINE__;
     /* must have 3 or multiples of 3 parameters.. it could possibliy have 1 extra param which
      * could be having commit and set to true/false */
-    if (!((i >= 3) && ((i % 3 == 0) || (i % 3 == 1))))
+    if (((strcmp("-s", argv[1]) == 0 ) && (i > 3)) || (!((i >= 3) && ((i % 3 == 0) || (i % 3 == 1)))))
     {
-        printf ("Invalid arguments. Please see the help\n\r");
+        RBUSCLI_LOG ("Invalid arguments. Please see the help\n\r");
         return;
     }
 
@@ -1475,7 +1477,7 @@ void validate_and_execute_set_cmd (int argc, char *argv[])
         if(value == false)
         {
             rc = RBUS_ERROR_INVALID_INPUT;
-            printf ("Invalid data value passed to set. Please pass proper value with respect to the data type\nsetvalues failed with return value: %d\n", rc);
+            RBUSCLI_LOG ("Invalid data value passed to set. Please pass proper value with respect to the data type\nsetvalues failed with return value: %d\n", rc);
             return;
         }
         if (type != RBUS_NONE)
@@ -1543,17 +1545,17 @@ void validate_and_execute_set_cmd (int argc, char *argv[])
         else
         {
             rc = RBUS_ERROR_INVALID_INPUT;
-            printf ("Invalid data type. Please see the help\n\r");
+            RBUSCLI_LOG ("Invalid data type. Please see the help\n\r");
         }
     }
 
     if(RBUS_ERROR_SUCCESS == rc)
     {
-        printf ("setvalues succeeded..\n\r");
+        RBUSCLI_LOG ("setvalues succeeded..\n\r");
     }
     else
     {
-        printf ("setvalues failed with return value: %d\n\r", rc);
+        RBUSCLI_LOG ("setvalues failed with return value: %d\n\r", rc);
     }
 }
 
@@ -3160,6 +3162,10 @@ int main( int argc, char *argv[] )
     }
     else
     {
+        if ((strcmp (argv[1], "-g") == 0) || (strcmp (argv[1], "-s") == 0))
+        {
+            g_isDebug = false;
+        }
         handle_cmds (argc, argv);
     }
 


### PR DESCRIPTION
Usage:
        rbuscli [-g  parameter ]
        rbuscli [-s  parameter type value ]
Options:
        -g Get the value of parameter
            ` ./rbuscli -g a.b.c`
        -s Set the value of parameter
             `./rbuscli -s a.b.c int 29`
             
 Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com
