### PR TITLE
Removed Carriage Return (\r) from the output of rbuscli -g option

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -1248,7 +1248,7 @@ void validate_and_execute_get_cmd (int argc, char *argv[])
 
 	    if ((strcmp("-g", argv[1]) == 0) && (!isWildCard))
 	    {
-		printf ("%s\n\r", pStrVal);
+		printf ("%s\n", pStrVal);
 	    }
 	    else
 	    {


### PR DESCRIPTION
Removed using of Carriage Return (\r) from the rbuscli -g option printf function.
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com