### PR TITLE
RDKB-51121 : Onewifi crash observed with function strlen, rtLogPrintf

### DIFF
--- a/sampleapps/consumer/rbusThreadConsumer.c
+++ b/sampleapps/consumer/rbusThreadConsumer.c
@@ -54,8 +54,9 @@ void *threadFunction(void *arg) {
 
 int main() {
     pthread_t threads[NUM_THREADS];
+    int i;
 
-    for (int i = 1; i <= NUM_THREADS; i++) {
+    for (i = 1; i <= NUM_THREADS; i++) {
         int result = pthread_create(&threads[i], NULL, threadFunction, &i);
         if (result != 0) {
             fprintf(stderr, "Error creating thread %d\n", i);
@@ -64,7 +65,7 @@ int main() {
         usleep(250000);
     }
 
-    for (int i = 1; i <= NUM_THREADS; i++) {
+    for (i = 1; i <= NUM_THREADS; i++) {
         pthread_join(threads[i], NULL);
     }
 


### PR DESCRIPTION
Reason for change: For fixing the testapp build error while building with jenkins
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>