### PR TITLE
RDKB-51177:RBUS- API to find event subscription

### DIFF
--- a/include/rbus.h
+++ b/include/rbus.h
@@ -1336,7 +1336,7 @@ rbusError_t rbusTable_unregisterRow(
   * @{ 
   */
 
-/** @fn bool rbusEvent_FindSubscription(
+/** @fn bool rbusEvent_IsSubscriptionExist(
  *          rbusHandle_t        handle,
  *          char const*         eventName,
  *          rbusEventSubscription_t*    subscription)
@@ -1350,7 +1350,7 @@ rbusError_t rbusTable_unregisterRow(
  *  @return     true or false
  *  @ingroup Events
  */
-bool  rbusEvent_FindSubscription(
+bool  rbusEvent_IsSubscriptionExist(
     rbusHandle_t        handle,
     char const*         eventName,
     rbusEventSubscription_t*    subscription);

--- a/include/rbus.h
+++ b/include/rbus.h
@@ -1336,6 +1336,25 @@ rbusError_t rbusTable_unregisterRow(
   * @{ 
   */
 
+/** @fn rbusEventSubscription_t rbusEvent_FindSubscription(
+ *          rbusHandle_t        handle,
+ *          char const*         eventName,
+ *          rbusEventSubscription_t*    subscription)
+ *  @brief Find active subscription given eventName with subscription structure.
+ *  Used by: Components that need to find whether they have active subscription
+ *  already or not for the given eventName with subscription structure.
+ *  The eventName should be a name which was previously subscribed
+ *  @param      handle          Bus Handle
+ *  @param      eventName       The fully qualified name of the event
+ *  @param      subscription    The subscription which was previously subscribed
+ *  @return rbusEventSubscription_t found subscription
+ *  @ingroup Events
+ */
+rbusEventSubscription_t*  rbusEvent_FindSubscription(
+    rbusHandle_t        handle,
+    char const*         eventName,
+    rbusEventSubscription_t*    subscription);
+
 /** @fn rbusError_t  rbusEvent_Subscribe(
  *          rbusHandle_t        handle,
  *          char const*         eventName,

--- a/include/rbus.h
+++ b/include/rbus.h
@@ -1336,7 +1336,7 @@ rbusError_t rbusTable_unregisterRow(
   * @{ 
   */
 
-/** @fn rbusEventSubscription_t rbusEvent_FindSubscription(
+/** @fn bool rbusEvent_FindSubscription(
  *          rbusHandle_t        handle,
  *          char const*         eventName,
  *          rbusEventSubscription_t*    subscription)
@@ -1347,10 +1347,10 @@ rbusError_t rbusTable_unregisterRow(
  *  @param      handle          Bus Handle
  *  @param      eventName       The fully qualified name of the event
  *  @param      subscription    The subscription which was previously subscribed
- *  @return rbusEventSubscription_t found subscription
+ *  @return     true or false
  *  @ingroup Events
  */
-rbusEventSubscription_t*  rbusEvent_FindSubscription(
+bool  rbusEvent_FindSubscription(
     rbusHandle_t        handle,
     char const*         eventName,
     rbusEventSubscription_t*    subscription);

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5046,7 +5046,7 @@ rbusError_t rbusEvent_UnsubscribeEx(
     return errorcode;
 }
 
-rbusEventSubscription_t* rbusEvent_FindSubscription(
+bool rbusEvent_FindSubscription(
     rbusHandle_t                handle,
     char const*                 eventName,
     rbusEventSubscription_t*    subscription)
@@ -5054,7 +5054,7 @@ rbusEventSubscription_t* rbusEvent_FindSubscription(
     if (handle == NULL)
     {
         RBUSLOG_ERROR("%s: failed, hanlder is NULL", __FUNCTION__);
-        return NULL;
+        return false;
     }
 
     struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
@@ -5070,19 +5070,16 @@ rbusEventSubscription_t* rbusEvent_FindSubscription(
         if (eventName == NULL)
         {
             RBUSLOG_ERROR("%s: failed, eventname is null", __FUNCTION__);
-            return NULL;
+            return false;
         }
         sub = rbusEventSubscription_find(handleInfo->eventSubs, eventName, NULL, 0, 0);
     }
 
     if (sub)
     {
-        return sub;
+        return true;
     }
-    else
-    {
-        return NULL;
-    }
+    return false;
 }
 
 

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5046,6 +5046,46 @@ rbusError_t rbusEvent_UnsubscribeEx(
     return errorcode;
 }
 
+rbusEventSubscription_t* rbusEvent_FindSubscription(
+    rbusHandle_t                handle,
+    char const*                 eventName,
+    rbusEventSubscription_t*    subscription)
+{
+    if (handle == NULL)
+    {
+        RBUSLOG_ERROR("%s: failed, hanlder is NULL", __FUNCTION__);
+        return NULL;
+    }
+
+    struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
+    rbusEventSubscription_t* sub = NULL;
+    if (subscription)
+    {
+        RBUSLOG_INFO("%s: %s", __FUNCTION__, subscription->eventName);
+        sub = rbusEventSubscription_find(handleInfo->eventSubs, subscription[0].eventName,
+                subscription[0].filter, subscription[0].interval, subscription[0].duration);
+    }
+    else
+    {
+        if (eventName == NULL)
+        {
+            RBUSLOG_ERROR("%s: failed, eventname is null", __FUNCTION__);
+            return NULL;
+        }
+        sub = rbusEventSubscription_find(handleInfo->eventSubs, eventName, NULL, 0, 0);
+    }
+
+    if (sub)
+    {
+        return sub;
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
+
 rbusError_t  rbusEvent_PublishRawData(
   rbusHandle_t          handle,
   rbusEventRawData_t*    eventData)

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5046,7 +5046,7 @@ rbusError_t rbusEvent_UnsubscribeEx(
     return errorcode;
 }
 
-bool rbusEvent_FindSubscription(
+bool rbusEvent_IsSubscriptionExist(
     rbusHandle_t                handle,
     char const*                 eventName,
     rbusEventSubscription_t*    subscription)

--- a/test/rbus/consumer/subscribe.c
+++ b/test/rbus/consumer/subscribe.c
@@ -320,7 +320,7 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     subscribeAsync(handle, "Device.TestProvider.Event1!", handler1, 20, RBUS_ERROR_SUCCESS, RBUS_ERROR_SUCCESS, 0, 300);
     if(gAsyncSuccess == 1)
     {
-        while((!rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) && (quit_counter--))
+        while((!rbusEvent_IsSubscriptionExist(handle, "Device.TestProvider.Event1!", NULL)) && (quit_counter--))
         {
             usleep(1000000);
         }
@@ -332,7 +332,7 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     subscribeAsync(handle, "Device.TestProvider.Event1!", handler1, -1, RBUS_ERROR_SUCCESS, RBUS_ERROR_SUCCESS, 0, 300);
     if(gAsyncSuccess == 1)
     {
-        while((!rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) && (quit_counter--))
+        while((!rbusEvent_IsSubscriptionExist(handle, "Device.TestProvider.Event1!", NULL)) && (quit_counter--))
         {
             usleep(1000000);
         }

--- a/test/rbus/consumer/subscribe.c
+++ b/test/rbus/consumer/subscribe.c
@@ -221,22 +221,6 @@ void unsubscribe(
         rc);
 }
 
-rbusEventSubscription_t* EventSubscription_find(rtVector eventSubs, char const* eventName, rbusFilter_t filter)
-{
-    size_t i = 0;
-    for(i=0; i < rtVector_Size(eventSubs); ++i)
-    {
-        rbusEventSubscription_t* sub = (rbusEventSubscription_t*)rtVector_At(eventSubs, i);
-        if(sub && !strcmp(sub->eventName, eventName) && !rbusFilter_Compare(sub->filter, filter))
-        {
-            printf("EventSubscription_find success\n");
-            return sub;
-        }
-    }
-    printf("EventSubscription_find error: can't find %s\n", eventName);
-    return NULL;
-}
-
 void subscribeAsync(
     rbusHandle_t handle, 
     char const* event, 
@@ -282,7 +266,6 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     int success;
     int maxTimeout = 30;
     int i;
-    struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
     unsigned int quit_counter = 10;
 
     /*changing from default so tests don't take 10 minutes for async sub to complete*/
@@ -337,7 +320,7 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     subscribeAsync(handle, "Device.TestProvider.Event1!", handler1, 20, RBUS_ERROR_SUCCESS, RBUS_ERROR_SUCCESS, 0, 300);
     if(gAsyncSuccess == 1)
     {
-        while(((EventSubscription_find(handleInfo->eventSubs, "Device.TestProvider.Event1!", NULL)) == NULL) && (quit_counter--))
+        while(((rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) == NULL) && (quit_counter--))
         {
             usleep(1000000);
         }
@@ -349,7 +332,7 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     subscribeAsync(handle, "Device.TestProvider.Event1!", handler1, -1, RBUS_ERROR_SUCCESS, RBUS_ERROR_SUCCESS, 0, 300);
     if(gAsyncSuccess == 1)
     {
-        while(((EventSubscription_find(handleInfo->eventSubs, "Device.TestProvider.Event1!", NULL)) == NULL) && (quit_counter--))
+        while(((rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) == NULL) && (quit_counter--))
         {
             usleep(1000000);
         }

--- a/test/rbus/consumer/subscribe.c
+++ b/test/rbus/consumer/subscribe.c
@@ -320,7 +320,7 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     subscribeAsync(handle, "Device.TestProvider.Event1!", handler1, 20, RBUS_ERROR_SUCCESS, RBUS_ERROR_SUCCESS, 0, 300);
     if(gAsyncSuccess == 1)
     {
-        while(((rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) == NULL) && (quit_counter--))
+        while((!rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) && (quit_counter--))
         {
             usleep(1000000);
         }
@@ -332,7 +332,7 @@ void testSubscribe(rbusHandle_t handle, int* countPass, int* countFail)
     subscribeAsync(handle, "Device.TestProvider.Event1!", handler1, -1, RBUS_ERROR_SUCCESS, RBUS_ERROR_SUCCESS, 0, 300);
     if(gAsyncSuccess == 1)
     {
-        while(((rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) == NULL) && (quit_counter--))
+        while((!rbusEvent_FindSubscription(handle, "Device.TestProvider.Event1!", NULL)) && (quit_counter--))
         {
             usleep(1000000);
         }


### PR DESCRIPTION
new method to support consumer to find whether they have active subscription already or not for the given DML with subscription structure.
Test Procedure: verified with ./rbusTestProvider & rbusTestConsumer
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com