### PR TITLE
LTE-2076 [Feild-Reported][INC] Bring Self heal logic to recover if rbus is stuck

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3011,7 +3011,7 @@ rbusError_t rbus_regDataElements(
 
     if((rc == RBUS_ERROR_SUCCESS) && (!sDisConnHandler))
     {
-        err = rbus_registerClientDisconnectHandler(_client_disconnect_callback_handler);
+        //err = rbus_registerClientDisconnectHandler(_client_disconnect_callback_handler);
         if(err != RBUSCORE_SUCCESS)
         {
             RBUSLOG_ERROR("%s : rbus_registerClientDisconnectHandler error %d", __FUNCTION__, err);


### PR DESCRIPTION
LTE-2076 [Feild-Reported][INC] Bring Self heal logic to recover if rbus is stuck

Reason for change: Experimental change to check RBus daemon stuck
Test Procedure: As mentioned in Jira
Risks: Medium
Priority: P1