### PR TITLE
RDKB-51301 : RBUS - Add mutex-protected to the Consumer side's subscriptions list

### DIFF
--- a/sampleapps/CMakeLists.txt
+++ b/sampleapps/CMakeLists.txt
@@ -133,6 +133,10 @@ add_executable(rbusThreadConsumer consumer/rbusThreadConsumer.c)
 add_dependencies(rbusThreadConsumer rbus)
 target_link_libraries(rbusThreadConsumer rbus)
 
+add_executable(rbusRawDataProvider provider/rbusRawDataProvider.c)
+add_dependencies(rbusRawDataProvider rbus)
+target_link_libraries(rbusRawDataProvider rbus)
+
 install (TARGETS
     rbusSampleProvider
     rbusSampleConsumer
@@ -157,6 +161,7 @@ install (TARGETS
     rbusDirectConsumer
     rbusThreadProvider
     rbusThreadConsumer
+    rbusRawDataProvider
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 endif (BUILD_RBUS_SAMPLE_APPS)

--- a/sampleapps/provider/rbusRawDataProvider.c
+++ b/sampleapps/provider/rbusRawDataProvider.c
@@ -1,0 +1,114 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2016 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <string.h>
+#include <getopt.h>
+#include <rbus.h>
+
+int loopFor = 30;
+int subscribed = 0;
+
+rbusError_t eventSubHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName, rbusFilter_t filter, int32_t interval, bool* autoPublish)
+{
+    (void)handle;
+    (void)filter;
+    (void)autoPublish;
+    (void)interval;
+
+    printf(
+        "eventSubHandler called:\n" \
+        "\taction=%s\n" \
+        "\teventName=%s\n",
+        action == RBUS_EVENT_ACTION_SUBSCRIBE ? "subscribe" : "unsubscribe",
+        eventName);
+
+    if(!strcmp("Device.Provider1.Event", eventName))
+    {
+        subscribed = action == RBUS_EVENT_ACTION_SUBSCRIBE ? 1 : 0;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+int main(int argc, char *argv[])
+{
+    (void)(argc);
+    (void)(argv);
+
+    rbusHandle_t handle;
+    int rc = RBUS_ERROR_SUCCESS;
+
+    char componentName[] = "RawDataEventProvider";
+
+    rbusDataElement_t dataElements[1] = {
+        {"Device.Provider1.Event", RBUS_ELEMENT_TYPE_EVENT, {NULL, NULL, NULL, NULL, eventSubHandler, NULL}}
+    };
+
+    printf("provider: start\n");
+
+    rc = rbus_open(&handle, componentName);
+    if(rc != RBUS_ERROR_SUCCESS)
+    {
+        printf("provider: rbus_open failed: %d\n", rc);
+        goto exit2;
+    }
+
+    rc = rbus_regDataElements(handle, 1, dataElements);
+    if(rc != RBUS_ERROR_SUCCESS)
+    {
+        printf("provider: rbus_regDataElements failed: %d\n", rc);
+        goto exit1;
+    }
+
+    while (loopFor != 0)
+    {
+        printf("provider: exiting in %d seconds\n", loopFor);
+        sleep(1);
+        loopFor--;
+
+        if(subscribed)
+        {
+            sleep(2);
+            printf("======= publishing RawData Event ===== \n");
+
+            rbusEventRawData_t event = {0};
+            event.name = dataElements[0].name;
+            event.rawData = "Hello";
+            event.rawDataLen = strlen("Hello");
+
+            rc = rbusEvent_PublishRawData(handle, &event);
+            if(rc != RBUS_ERROR_SUCCESS)
+                printf("provider: rbusEvent_PublishRawData Event failed: %d\n", rc);
+        }
+
+    }
+    rbus_unregDataElements(handle, 1, dataElements);
+exit1:
+    rbus_close(handle);
+exit2:
+    printf("provider: exit\n");
+    return rc;
+}

--- a/sampleapps/provider/rbusRawDataProvider.c
+++ b/sampleapps/provider/rbusRawDataProvider.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
             rbusEventRawData_t event = {0};
             event.name = dataElements[0].name;
             event.rawData = "Hello";
-            event.rawDataLen = strlen("Hello");
+            event.rawDataLen = strlen("Hello")+1;
 
             rc = rbusEvent_PublishRawData(handle, &event);
             if(rc != RBUS_ERROR_SUCCESS)

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4634,7 +4634,7 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
             if (!(subInternal && subInternal->dirty))
                 rbusEventSubscription_free(sub);
 
-            return RBUS_ERROR_DESTINATION_NOT_REACHABLE;
+            return RBUS_ERROR_TIMEOUT;
         }
         else if(providerError != RBUS_ERROR_SUCCESS)
         {   


### PR DESCRIPTION
Reason for change: The subscriptions list on the consumer side is not mutex protected. As a result, when some component subscribes/unsubscribes the event, it affects the subscription list at the same time.

Test Procedure: Verified with TestProvider & TestConsumer
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com