### PR TITLE
RDKB-51386 : Addition of RBUS heart beat monitor service

### DIFF
--- a/conf/rbus.service
+++ b/conf/rbus.service
@@ -23,7 +23,7 @@ Description= An IPC framework
 Type=forking
 TimeoutSec=300
 ExecStart=/usr/bin/rtrouted $RTROUTER_OPTIONAL_ARGS
-ExecStopPost=/bin/sh -c 'echo 0 >> /tmp/rbus_stopped'
+ExecStopPost=/bin/sh -c 'echo 0 > /tmp/rbus_stopped'
 Restart=no
 
 

--- a/conf/rbus_heartbeat.service
+++ b/conf/rbus_heartbeat.service
@@ -17,9 +17,14 @@
 # limitations under the License.
 ##########################################################################
 [Unit]
-Description=RBus IPC Restart Service
+Description= To check whether the rtrouted process is running or not
+Requires=rbus.service
+OnFailure=rbus_monitor.service
 
 [Service]
-Type=simple
-ExecStartPre=/bin/sh -c "if [[ ! -f /tmp/rbus_stopped ]]; then echo rbus_stuck > /tmp/rbus_stopped;fi"
-ExecStart=/bin/sh -c "if [[ -e /lib/rdk/rbus_termination_handler.sh ]]; then /lib/rdk/rbus_termination_handler.sh; fi"
+Type=oneshot
+TimeoutStartSec=10s
+ExecStart=/usr/bin/rtrouted_diag heartbeat
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/rbus_heartbeat.timer
+++ b/conf/rbus_heartbeat.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=rbus heart beat timer
+
+[Timer]
+OnBootSec=6min
+OnUnitActiveSec=2min
+
+[Install]
+WantedBy=timers.target

--- a/src/rtmessage/diag_probe.c
+++ b/src/rtmessage/diag_probe.c
@@ -29,35 +29,39 @@
 
 int main(int argc, char * argv[])
 {
-    printf( "----------\nHelp:\n"
-            "Syntax: rtm_diag_probe <command>\n"
-            "Following commands are supported:\n"
-            "%-20s - Enable debug level logs in router.\n"
-            "%-20s - Disable debug level logs in router.\n"
-            "%-20s - Ask router to additionally listen to new socket.\n"
-            "%-20s - Log routing tree stats.\n"
-            "%-20s - Log routing tree topics.\n"
-            "%-20s - Log routing tree routes.\n"
-            "%-20s - Enable bus traffic logging.\n"
-            "%-20s - Disable bus traffic logging.\n"
-            "%-20s - Dump raw benchmark data to rtrouted logs.\n"
-            "%-20s - Reset data collected so far for benchmarking.\n"
-            "%-20s - Shutdown the server.\n"
-            "----------\n",
-            RTROUTER_DIAG_CMD_ENABLE_VERBOSE_LOGS,
-            RTROUTER_DIAG_CMD_DISABLE_VERBOSE_LOGS,
-            RTROUTER_DIAG_CMD_ADD_NEW_LISTENER,
-            RTROUTER_DIAG_CMD_LOG_ROUTING_STATS,
-            RTROUTER_DIAG_CMD_LOG_ROUTING_TOPICS,
-            RTROUTER_DIAG_CMD_LOG_ROUTING_ROUTES,
-            RTROUTER_DIAG_CMD_ENABLE_TRAFFIC_MONITOR,
-            RTROUTER_DIAG_CMD_DISABLE_TRAFFIC_MONITOR,
-            RTROUTER_DIAG_CMD_DUMP_BENCHMARKING_DATA,
-            RTROUTER_DIAG_CMD_RESET_BENCHMARKING_DATA,
-            RTROUTER_DIAG_CMD_SHUTDOWN
-    );
-
-    if(1 != argc)
+    if(1 == argc)
+    {
+        printf( "----------\nHelp:\n"
+                "Syntax: rtrouted_diag <command>\n"
+                "Following commands are supported:\n"
+                "%-20s - Enable debug level logs in router.\n"
+                "%-20s - Disable debug level logs in router.\n"
+                "%-20s - Ask router to additionally listen to new socket.\n"
+                "%-20s - Heart beat monitoring for rtrouted\n"
+                "%-20s - Log routing tree stats.\n"
+                "%-20s - Log routing tree topics.\n"
+                "%-20s - Log routing tree routes.\n"
+                "%-20s - Enable bus traffic logging.\n"
+                "%-20s - Disable bus traffic logging.\n"
+                "%-20s - Dump raw benchmark data to rtrouted logs.\n"
+                "%-20s - Reset data collected so far for benchmarking.\n"
+                "%-20s - Shutdown the server.\n"
+                "----------\n",
+                RTROUTER_DIAG_CMD_ENABLE_VERBOSE_LOGS,
+                RTROUTER_DIAG_CMD_DISABLE_VERBOSE_LOGS,
+                RTROUTER_DIAG_CMD_ADD_NEW_LISTENER,
+                RTROUTER_DIAG_CMD_HEARTBEAT,
+                RTROUTER_DIAG_CMD_LOG_ROUTING_STATS,
+                RTROUTER_DIAG_CMD_LOG_ROUTING_TOPICS,
+                RTROUTER_DIAG_CMD_LOG_ROUTING_ROUTES,
+                RTROUTER_DIAG_CMD_ENABLE_TRAFFIC_MONITOR,
+                RTROUTER_DIAG_CMD_DISABLE_TRAFFIC_MONITOR,
+                RTROUTER_DIAG_CMD_DUMP_BENCHMARKING_DATA,
+                RTROUTER_DIAG_CMD_RESET_BENCHMARKING_DATA,
+                RTROUTER_DIAG_CMD_SHUTDOWN
+                    );
+    }
+    else
     {
         rtConnection con;
         rtLog_SetLevel(RT_LOG_INFO);
@@ -70,7 +74,7 @@ int main(int argc, char * argv[])
         if (argv[2] != NULL)
             rtMessage_SetString(out, RTROUTER_DIAG_CMD_VALUE, argv[2]);
 
-        rtConnection_SendMessage(con, out, "_RTROUTED.INBOX.DIAG");
+        rtConnection_SendMessage(con, out, RTROUTER_DIAG_DESTINATION);
 
         sleep(1);
 

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1203,6 +1203,10 @@ rtRouted_OnMessageDiagnostics(rtConnectedClient* sender, rtMessageHeader* hdr, u
       }
     }
   }
+  else if(0 == strncmp(RTROUTER_DIAG_CMD_HEARTBEAT, cmd, sizeof(RTROUTER_DIAG_CMD_HEARTBEAT)))
+  {
+    rtLog_Debug("rtrouted process is running fine");
+  }
   else if(0 == strncmp(RTROUTER_DIAG_CMD_DUMP_BENCHMARKING_DATA, cmd, sizeof(RTROUTER_DIAG_CMD_DUMP_BENCHMARKING_DATA)))
   {
     benchmark_print_stats("diagnostics");

--- a/src/rtmessage/rtrouter_diag.h
+++ b/src/rtmessage/rtrouter_diag.h
@@ -39,5 +39,6 @@
 
 #define RTROUTER_DIAG_CMD_ADD_NEW_LISTENER          "addNewListener"
 #define RTROUTER_DIAG_CMD_SHUTDOWN                  "shutdown"
+#define RTROUTER_DIAG_CMD_HEARTBEAT                 "heartbeat"
 
 #endif


### PR DESCRIPTION
Reason for change: Added rbus_heartbeat.service file to monitor the status
of rtrouted. Using rtrouted_diag, a separate parameter has been added for
heartbeat monitoring which will just call rtConnection_sendmessage to confirm
the rtrouted is running properly or not. If the sendmessage is failed,
rtrouted will be killed and the device will be rebooted.
Test Procedure: Tested by simulation
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>
