### PR TITLE
RDKB-51547 : Implementation of RBUS Publish API to send Raw Data

### DIFF
--- a/include/rbus.h
+++ b/include/rbus.h
@@ -127,7 +127,9 @@ typedef enum _rbusError
     RBUS_ERROR_INVALID_METHOD,                  /**< Invalid Method           */
     RBUS_ERROR_NOSUBSCRIBERS,                   /**< No subscribers present   */
     RBUS_ERROR_SUBSCRIPTION_ALREADY_EXIST,      /**< The subscription already exists*/
-    RBUS_ERROR_INVALID_NAMESPACE                /**< Invalid namespace as per standard */
+    RBUS_ERROR_INVALID_NAMESPACE,               /**< Invalid namespace as per standard */
+    RBUS_ERROR_DIRECT_CON_NOT_EXIST,            /**< Direct connection not exist */
+    RBUS_ERROR_DIRECT_SEND_FAILURE              /**< Direct connection send failure */
 } rbusError_t;
 
 

--- a/include/rbus_message.h
+++ b/include/rbus_message.h
@@ -95,6 +95,25 @@ rbusError_t rbusMessage_AddListener(
     rbusMessageHandler_t handler,
     void* userData);
 
+/** @fn rbusError_t rbusMessage_AddPrivateListener(
+ *          rbusHandle_t handle,
+ *          char const* expression,
+ *          rbusMessageHandler_t callback,
+ *          void * userData)
+ *  @brief  Add a message for private listener created for direct mode.
+ *  @param  handle Bus Handle
+ *  @param  expression A topic or a topic expression
+ *  @param  handler The message callback handler
+ *  @param  userData User data to be passed back to the callback handler
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR
+ */
+rbusError_t rbusMessage_AddPrivateListener(
+    rbusHandle_t handle,
+    char const* expression,
+    rbusMessageHandler_t handler,
+    void* userData);
+
 /** @fn rbusError_t rbusMessage_RemoveListener(
  *          rbusHandle_t handle,
  *          char const* expression)
@@ -130,6 +149,34 @@ rbusError_t rbusMessage_RemoveAllListeners(
  *  @return RBus error code as defined by rbusError_t.
  *  Possible errors are: RBUS_ERROR_BUS_ERROR, RBUS_ERROR_DESTINATION_NOT_FOUND
  */
+
+/** @fn rbusError_t rbusMessage_RemovePrivateListener(
+ *          rbusHandle_t handle,
+ *          char const* expression)
+ *  @brief  Remove a message for private listener created for direct mode.
+ *  @param  handle Bus Handle
+ *  @param  expression A topic or a topic expression
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR
+ */
+rbusError_t rbusMessage_RemovePrivateListener(
+    rbusHandle_t handle,
+    char const* expression,
+    uint32_t userDataID);
+
+/** @fn rbusError_t rbusMessage_HasListener(
+ *          rbusHandle_t handle,
+ *          char const* listener)
+ *  @brief  Check whether the listener exist for the handle connection.
+ *  @param  handle Bus Handle
+ *  @param  listener name
+ *  @return RBus error code as defined by rbusError_t.
+ *  Possible errors are: RBUS_ERROR_BUS_ERROR
+ */
+int rbusMessage_HasListener(
+    rbusHandle_t handle,
+    char const* listener);
+
 rbusError_t rbusMessage_Send(
     rbusHandle_t handle,
     rbusMessage_t* message,

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -370,7 +370,7 @@ static int unlock()
 	return pthread_mutex_unlock(&g_mutex);
 }
 
-static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response);
+static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response, bool rawDataSub);
 
 static void perform_init()
 {
@@ -410,7 +410,7 @@ static void perform_cleanup()
             for(i2 = 0; i2 < sz2; i2++)
             {   
                 client_event_t event = rtVector_At(sub->events, i2);
-                send_subscription_request(sub->object, event->name, false, NULL, NULL, 0, false, NULL);
+                send_subscription_request(sub->object, event->name, false, NULL, NULL, 0, false, NULL, false);
             }
         }
         lock();
@@ -698,7 +698,7 @@ rtConnection rbus_getConnection()
     return g_connection;
 }
 
-static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout_ms, bool publishOnSubscribe, rbusMessage *response)
+static rbusCoreError_t send_subscription_request(const char * object_name, const char * event_name, bool activate, const rbusMessage payload, int* providerError, int timeout_ms, bool publishOnSubscribe, rbusMessage *response, bool rawDataSub)
 {
     /* Method definition to add new event subscription: 
      * method name: METHOD_ADD_EVENT_SUBSCRIPTION / METHOD_REMOVE_EVENT_SUBSCRIPTION.
@@ -717,6 +717,10 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
         rbusMessage_SetMessage(request, payload);
     if(publishOnSubscribe)
         rbusMessage_SetInt32(request, 1); /*for publishOnSubscribe */
+    else
+        rbusMessage_SetInt32(request, 0);
+    if(rawDataSub)
+        rbusMessage_SetInt32(request, 1); /*for rawdatasubscription */
     else
         rbusMessage_SetInt32(request, 0);
 
@@ -808,7 +812,7 @@ rbusCoreError_t rbus_registerObj(const char * object_name, rbus_callback_t handl
     server_object_create(&obj, object_name, handler, user_data);
 
     //TODO: callback signature translation. rbusMessage uses a significantly wider signature for callbacks. Translate to something simpler.
-    err = rtConnection_AddListener(g_connection, object_name, onMessage, obj);
+    err = rtConnection_AddListener(g_connection, object_name, onMessage, obj, 0);
 
     if(RT_OK == err)
     {
@@ -1539,7 +1543,7 @@ static rbusCoreError_t remove_subscription_callback(const char * object_name,  c
     return ret;
 }
 
-static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response)
+static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response, bool rawDataSub)
 {
     /*using namespace rbus_client;*/
     rbusCoreError_t ret = RBUSCORE_SUCCESS;
@@ -1612,7 +1616,7 @@ static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  
 
     unlock();
 
-    if((ret = send_subscription_request(object_name, event_name, true, payload, providerError, timeout, publishOnSubscribe, response)) != RBUSCORE_SUCCESS)
+    if((ret = send_subscription_request(object_name, event_name, true, payload, providerError, timeout, publishOnSubscribe, response, rawDataSub)) != RBUSCORE_SUCCESS)
     {
         if(g_master_event_callback == NULL)
         {
@@ -1627,12 +1631,12 @@ static rbusCoreError_t rbus_subscribeToEventInternal(const char * object_name,  
 
 rbusCoreError_t rbus_subscribeToEvent(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError)
 {
-    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, 0, false, NULL);
+    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, 0, false, NULL, false);
 }
 
-rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response)
+rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout, bool publishOnSubscribe, rbusMessage *response, bool rawDataSub)
 {
-    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, timeout, publishOnSubscribe, response);
+    return rbus_subscribeToEventInternal(object_name, event_name, callback, payload, user_data, providerError, timeout, publishOnSubscribe, response, rawDataSub);
 }
 
 rbusCoreError_t rbus_unsubscribeFromEvent(const char * object_name,  const char * event_name, const rbusMessage payload)
@@ -1658,7 +1662,7 @@ rbusCoreError_t rbus_unsubscribeFromEvent(const char * object_name,  const char 
 
     if(!g_master_event_callback)
         remove_subscription_callback(object_name, event_name);
-    ret = send_subscription_request(object_name, event_name, false, payload, NULL, 0, false, NULL);
+    ret = send_subscription_request(object_name, event_name, false, payload, NULL, 0, false, NULL, false);
     return ret;
 }
 
@@ -1764,7 +1768,7 @@ rbusCoreError_t rbus_registerClientDisconnectHandler(rbus_client_disconnect_call
     lock();
     if(!g_advisory_listener_installed)
     {
-        rtError err = rtConnection_AddListener(g_connection, RTMSG_ADVISORY_TOPIC, &rtrouted_advisory_callback, g_connection);
+        rtError err = rtConnection_AddListener(g_connection, RTMSG_ADVISORY_TOPIC, &rtrouted_advisory_callback, g_connection, 0);
         if(err == RT_OK)
         {
             RBUSCORELOG_DEBUG("Listening for advisory messages");
@@ -1817,7 +1821,7 @@ rbusCoreError_t rbus_publishSubscriberEvent(const char* object_name,  const char
         uint8_t* data;
         uint32_t dataLength;
         rbusMessage_ToBytes(out, &data, &dataLength);
-        rtRouteDirect_SendMessage (pPrivCliInfo, data, dataLength);
+        rtRouteDirect_SendMessage (pPrivCliInfo, data, dataLength, 0);
     }
     else
     {

--- a/src/core/rbuscore.h
+++ b/src/core/rbuscore.h
@@ -22,6 +22,7 @@
 #include <rtMessageHeader.h>
 #include <rtConnection.h>
 #include "rbuscore_types.h"
+#include <rtrouteBase.h>
 #include "rbuscore_message.h"
 #include <rtm_discovery_api.h>
 
@@ -142,7 +143,7 @@ rbusCoreError_t rbus_subscribeToEvent(const char * object_name,  const char * ev
 /* Subscribe to 'event_name' events from 'object_name' object, with the specified timeout. If the timeout is less than or equal to zero, timeout will be set to 1000.
  * If the object supports only one event, event_name can be NULL. If the event_name is an alias for the object, then object_name can be NULL. The installed callback will be invoked every time 
  * a matching event is received. */
-rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout_ms, bool publishOnSubscribe, rbusMessage *response);
+rbusCoreError_t rbus_subscribeToEventTimeout(const char * object_name,  const char * event_name, rbus_event_callback_t callback, const rbusMessage payload, void * user_data, int* providerError, int timeout_ms, bool publishOnSubscribe, rbusMessage *response, bool rawDataSub);
 
 /* Unsubscribe from receiving 'event_name' events from 'object_name' object. If the object supports only one event, event_name can be NULL. */
 rbusCoreError_t rbus_unsubscribeFromEvent(const char * object_name,  const char * event_name, const rbusMessage payload);
@@ -226,6 +227,7 @@ rbusCoreError_t rbuscore_startPrivateListener(const char* pPrivateConnAddress, c
 /* The Provider application to request to remove/close the instance of rtrouted in the given DML */
 rbusCoreError_t rbuscore_updatePrivateListener(const char* pConsumerName, const char *pDMLName);
 
+const rtPrivateClientInfo* _rbuscore_find_server_privateconnection(const char *pParameterName, const char *pConsumerName);
 
 #ifdef __cplusplus
 }

--- a/src/rbus/rbus_handle.h
+++ b/src/rbus/rbus_handle.h
@@ -62,6 +62,7 @@ struct _rbusHandle
 
   rtVector              messageCallbacks;
   rtConnection          m_connection;
+  rtConnection          m_connectionParent;
   rbusHandleType_t      m_handleType;
   pthread_mutex_t       handleMutex;
 };

--- a/src/rbus/rbus_subscriptions.c
+++ b/src/rbus/rbus_subscriptions.c
@@ -113,7 +113,7 @@ void rbusSubscriptions_destroy(rbusSubscriptions_t subscriptions)
 static void rbusSubscriptions_onSubscriptionCreated(rbusSubscription_t* sub, elementNode* node);
 
 /*add a new subscription*/
-rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscriptions, char const* listener, char const* eventName, int32_t componentId, rbusFilter_t filter, int32_t interval, int32_t duration, bool autoPublish, elementNode* registryElem)
+rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscriptions, char const* listener, char const* eventName, int32_t componentId, rbusFilter_t filter, int32_t interval, int32_t duration, bool autoPublish, elementNode* registryElem, uint32_t userDataID)
 {
     rbusSubscription_t* sub;
     TokenChain* tokens;
@@ -142,6 +142,7 @@ rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscr
     sub->autoPublish = autoPublish;
     sub->element = registryElem;
     sub->tokens = tokens;
+    sub->userDataID = userDataID;
     rtList_Create(&sub->instances);
     rtList_PushBack(subscriptions->subList, sub, NULL);
 

--- a/src/rbus/rbus_subscriptions.h
+++ b/src/rbus/rbus_subscriptions.h
@@ -46,6 +46,7 @@ typedef struct _rbusSubscription
     rtList instances;           /* the instance elements e.g.   Device.WiFi.AccessPoint.1.AssociatedDevice.1.SignalStrength
                                                                 Device.WiFi.AccessPoint.1.AssociatedDevice.2.SignalStrength
                                                                 Device.WiFi.AccessPoint.2.AssociatedDevice.1.SignalStrength */
+    uint32_t userDataID;
 } rbusSubscription_t;
 
 /*create a new subscriptions registry for an rbus handle*/
@@ -55,7 +56,7 @@ void rbusSubscriptions_create(rbusSubscriptions_t* subscriptions, rbusHandle_t h
 void rbusSubscriptions_destroy(rbusSubscriptions_t subscriptions);
 
 /*add a new subscription with unique key [listener, eventName, filter] and the corresponding*/
-rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscriptions, char const* listener, char const* eventName, int32_t componentId, rbusFilter_t filter, int32_t interval, int32_t duration, bool autoPublish, elementNode* registryElem);
+rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscriptions, char const* listener, char const* eventName, int32_t componentId, rbusFilter_t filter, int32_t interval, int32_t duration, bool autoPublish, elementNode* registryElem, uint32_t userDataID);
 
 /*get an existing subscription by searching for its unique key [listener, eventName, filter]*/
 rbusSubscription_t* rbusSubscriptions_getSubscription(rbusSubscriptions_t subscriptions, char const* listener, char const* eventName, int32_t componentId, rbusFilter_t filter);

--- a/src/rtmessage/rtConnection.h
+++ b/src/rtmessage/rtConnection.h
@@ -186,7 +186,7 @@ rtConnection_SendBinaryResponse(rtConnection con, rtMessageHeader const* request
  */
 rtError
 rtConnection_AddListener(rtConnection con, char const* expression,
-  rtMessageCallback callback, void* closure);
+  rtMessageCallback callback, void* closure, uint32_t userDataID);
 
 /**
  * Remove a callback listener

--- a/src/rtmessage/rtMessageHeader.c
+++ b/src/rtmessage/rtMessageHeader.c
@@ -37,6 +37,7 @@ rtMessageHeader_Init(rtMessageHeader* hdr)
   memset(hdr->topic, 0, RTMSG_HEADER_MAX_TOPIC_LENGTH);
   hdr->reply_topic_length = 0;
   memset(hdr->reply_topic, 0, RTMSG_HEADER_MAX_TOPIC_LENGTH);
+  hdr->user_data_ID = 0;
 #ifdef MSG_ROUNDTRIP_TIME
   hdr->T1 = 0;
   hdr->T2 = 0;
@@ -52,11 +53,11 @@ rtMessageHeader_Encode(rtMessageHeader* hdr, uint8_t* buff)
 {
   uint8_t* ptr = buff;
 #ifdef MSG_ROUNDTRIP_TIME
-  static uint16_t const kSizeWithoutStringsInBytes = 52; /* 28 bytes for basic data +
+  static uint16_t const kSizeWithoutStringsInBytes = 56; /* 28 bytes for basic data +
                                                              4 bytes for Marker +
                                                             20 bytes for timestamp */
 #else
-  static uint16_t const kSizeWithoutStringsInBytes = 32; /* 28 bytes for basic data +
+  static uint16_t const kSizeWithoutStringsInBytes = 36; /* 28 bytes for basic data +
                                                              4 bytes for Marker */
 #endif
   uint16_t length = kSizeWithoutStringsInBytes
@@ -72,6 +73,7 @@ rtMessageHeader_Encode(rtMessageHeader* hdr, uint8_t* buff)
   rtEncoder_EncodeUInt32(&ptr, hdr->payload_length);
   rtEncoder_EncodeString(&ptr, hdr->topic, NULL);
   rtEncoder_EncodeString(&ptr, hdr->reply_topic, NULL);
+  rtEncoder_EncodeUInt32(&ptr, hdr->user_data_ID);
 #ifdef MSG_ROUNDTRIP_TIME
   rtEncoder_EncodeUInt32(&ptr, hdr->T1);
   rtEncoder_EncodeUInt32(&ptr, hdr->T2);
@@ -119,6 +121,7 @@ rtMessageHeader_Decode(rtMessageHeader* hdr, uint8_t const* buff)
     return RT_ERROR;
   }
   rtEncoder_DecodeStr(&ptr, hdr->reply_topic, hdr->reply_topic_length);
+  rtEncoder_DecodeUInt32(&ptr, (uint32_t*)&hdr->user_data_ID);
 #ifdef MSG_ROUNDTRIP_TIME
   rtEncoder_DecodeUInt32(&ptr, (uint32_t*)&hdr->T1);
   rtEncoder_DecodeUInt32(&ptr, (uint32_t*)&hdr->T2);

--- a/src/rtmessage/rtMessageHeader.h
+++ b/src/rtmessage/rtMessageHeader.h
@@ -63,6 +63,7 @@ typedef struct
   char     topic[RTMSG_HEADER_MAX_TOPIC_LENGTH];
   uint32_t reply_topic_length;
   char     reply_topic[RTMSG_HEADER_MAX_TOPIC_LENGTH];
+  uint32_t user_data_ID;
 #ifdef MSG_ROUNDTRIP_TIME
   time_t   T1; /* Time at which consumer sends the request to daemon */
   time_t   T2; /* Time at which daemon receives the message from consumer */

--- a/src/rtmessage/rtrouteBase.c
+++ b/src/rtmessage/rtrouteBase.c
@@ -497,7 +497,7 @@ rtRouteDirect_AcceptClientConnection(rtListener* listener)
 }
 
 rtError
-rtRouteDirect_SendMessage(const rtPrivateClientInfo* pClient, uint8_t const* pInBuff, int inLength)
+rtRouteDirect_SendMessage(const rtPrivateClientInfo* pClient, uint8_t const* pInBuff, int inLength, uint32_t userDataID)
 {
     rtError ret = RT_OK;
     rtMessageHeader new_header;
@@ -508,7 +508,10 @@ rtRouteDirect_SendMessage(const rtPrivateClientInfo* pClient, uint8_t const* pIn
         rtMessageHeader_Init(&new_header);
         new_header.sequence_number = 1;
         new_header.flags = rtMessageFlags_RawBinary;
-        new_header.control_data = pClient->clientID;
+        if(userDataID)
+            new_header.control_data = userDataID; /* Rawdata unique subscription ID */
+        else
+            new_header.control_data = pClient->clientID;
      
         strncpy(new_header.topic, pClient->clientTopic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
         new_header.topic_length = strlen(pClient->clientTopic);

--- a/src/rtmessage/rtrouteBase.h
+++ b/src/rtmessage/rtrouteBase.h
@@ -81,6 +81,6 @@ rtError rtRouteBase_BindListener(char const* socket_name, int no_delay, int inde
 rtError rtRouteBase_CloseListener(rtListener *pListener);
 
 rtError rtRouteDirect_StartInstance(const char* socket_name, rtDriectClientHandler messageHandler);
-rtError rtRouteDirect_SendMessage(const rtPrivateClientInfo* pClient, uint8_t const* pInBuff, int inLength);
+rtError rtRouteDirect_SendMessage(const rtPrivateClientInfo* pClient, uint8_t const* pInBuff, int inLength, uint32_t userDataID);
 
 #endif /* __RTROUTEBASE_H__ */

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -637,6 +637,7 @@ rtRouted_ForwardMessage(rtConnectedClient* sender, rtMessageHeader* hdr, uint8_t
   new_header.topic_length = hdr->topic_length;
   new_header.reply_topic_length = hdr->reply_topic_length;
   new_header.flags = hdr->flags;
+  new_header.user_data_ID = hdr->user_data_ID;
   strncpy(new_header.topic, hdr->topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
   strncpy(new_header.reply_topic, hdr->reply_topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
 #ifdef MSG_ROUNDTRIP_TIME

--- a/unittests/rbus_unit_test_event_client.cpp
+++ b/unittests/rbus_unit_test_event_client.cpp
@@ -192,9 +192,9 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test1)
     printf("*********************  CREATING CLIENT : %s \n", client_name);
     conn_status = CALL_RBUS_OPEN_BROKER_CONNECTION(client_name);
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
     printf("********************Subscribed Events with Event name: event_1 in 1000 ms \n");
     conn_status = CALL_RBUS_CLOSE_BROKER_CONNECTION();
@@ -211,20 +211,20 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test2)
     conn_status = CALL_RBUS_OPEN_BROKER_CONNECTION(client_name);
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Test with invalid objname passed
-    err = rbus_subscribeToEventTimeout(NULL, "event_1", &event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(NULL, "event_1", &event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_ERROR_DESTINATION_UNREACHABLE) << "rbus_subscribeToEventTimeout failed";
     //Test with the event name  to be NULL
-    err = rbus_subscribeToEventTimeout(obj_name, "NULL", &event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "NULL", &event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_ERROR_GENERAL) << "rbus_subscribeToEventTimeout failed";
     //Test with the callback to be NULL
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",NULL, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",NULL, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     //Test with the valid Event name, objname, Callback
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
     printf("Subscribed Events with Event name: event_1 \n");
     //Test with the already subscribed Event
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_SUCCESS) << "rbus_subscribeToEventTimeout failed";
     conn_status = CALL_RBUS_CLOSE_BROKER_CONNECTION();
     ASSERT_EQ(conn_status, true) << "RBUS_CLOSE_BROKER_CONNECTION failed";
@@ -241,7 +241,7 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test3)
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Boundary Test with MAX_OBJECT_NAME_LENGTH
     memset(obj_name, 't', (sizeof(obj_name)- 1));
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     conn_status = CALL_RBUS_CLOSE_BROKER_CONNECTION();
     ASSERT_EQ(conn_status, true) << "RBUS_CLOSE_BROKER_CONNECTION failed";

--- a/unittests/rbus_unit_test_event_server.cpp
+++ b/unittests/rbus_unit_test_event_server.cpp
@@ -319,19 +319,19 @@ TEST_F(EventServerAPIs, rbus_subscribeToEventTimeout_test1)
     char event_name[130] ="0";
     rbusCoreError_t err = RBUSCORE_SUCCESS;
     //Neg test subscribe before establishing connection
-    err = rbus_subscribeToEventTimeout("obj_name", "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout("obj_name", "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_STATE) << "rbus_subscribeToEventTimeout failed";
     RBUS_OPEN_BROKER_CONNECTION(client_name,RBUSCORE_SUCCESS);
     //Neg Test with more than MAX_OBJECT_NAME_LENGTH
     memset(obj_name, 't', (sizeof(obj_name)- 1));
-    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(obj_name, "event_1",&event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     //Neg Test with more than MAX_EVENT_NAME_LENGTH
     memset(event_name, 't', (sizeof(obj_name)- 1));
-    err = rbus_subscribeToEventTimeout("object_1", event_name, &event_callback, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout("object_1", event_name, &event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     //Neg test passing object name and callback as NULL
-    err = rbus_subscribeToEventTimeout(NULL, "event_1",NULL, NULL, NULL, NULL, 1000, false, NULL);
+    err = rbus_subscribeToEventTimeout(NULL, "event_1",NULL, NULL, NULL, NULL, 1000, false, NULL, false);
     EXPECT_EQ(err,RBUSCORE_ERROR_INVALID_PARAM) << "rbus_subscribeToEventTimeout failed";
     RBUS_CLOSE_BROKER_CONNECTION(RBUSCORE_SUCCESS);
 }


### PR DESCRIPTION
Reason for change: Modified the exisiting RawData API to support publish and subscribe for direct mode. Along with that changed the raw data topic name of add and remove listener with the new unique name created from the subscription ID added in the header. So that each raw data subscription will have a unique topic added to the broker
Test Procedure: Test and verified with rbuscli
Risks: Medium
Priority: P0
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>