### PR TITLE
RDKB-51760 - Provider crash with multiple rbus_open() call

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2679,8 +2679,6 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
 
     LockMutex();
 
-    _rbus_open_pre_initialize(true);
-
     /*
         Per spec: If a component calls this API more than once, any previous busHandle 
         and all previous data element registrations will be canceled.
@@ -2694,6 +2692,8 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
         rbus_close(tmpHandle);
         LockMutex();
     }
+
+    _rbus_open_pre_initialize(true);
 
     if(rbusHandleList_IsFull())
     {


### PR DESCRIPTION
Reason for change: With multiple rbus_open() call with same component name, we are closing and opening the handle again. After closing the handle, we are not performing rbusConfig_CreateOnce(), because of which in rbus_regDataElements() where we are calling rbusConfig_Get()->tmpDir leads to a NULL pointer deferencing. Made changes to call _rbus_open_pre_initialize() in the issue scenario. Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>