### PR TITLE
LTE-2173: [XLE][23Q4] XLE and XB are in split brain mode always

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1773,8 +1773,7 @@ int main(int argc, char* argv[])
     rtLog_Warn("another instance of rtrouted is already running");
     exit(12);
   }
-
-  mkdir("/tmp/.rbus", 0700);
+  mkdir("/tmp/.rbus", 0775);
 #ifdef ENABLE_RDKLOGGER
     rdk_logger_init("/etc/debug.ini");
 #endif


### PR DESCRIPTION
Reason for change: The provider is unable to access the subscribers' component ID file due to the restricted access permission of the '/tmp/.rbus' directory. Modified directory permission to access it.
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com