### PR TITLE
 RDKB-51761 : Test Suite Enhancements

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,6 +63,13 @@ jobs:
           export LD_LIBRARY_PATH=$PREFIX/lib
           nohup ./bin/rbusTestProvider >/tmp/plog.txt &
           ./bin/rbusTestConsumer -a
+      - name: Run multiRbusOpenMethod Unit test 
+        run: |
+          cd install/usr
+          export PREFIX=$PWD
+          export LD_LIBRARY_PATH=$PREFIX/lib
+          nohup ./bin/multiRbusOpenMethodProvider >/tmp/log_multiRbusOpenMethodProvider.txt &
+          ./bin/multiRbusOpenMethodConsumer
       - name: Run multiRbusOpenSubscribe Unit test
         run: |
           cd install/usr

--- a/test/rbus/multiRbusOpenMethodConsumer/multiRbusOpenMethodConsumer.c
+++ b/test/rbus/multiRbusOpenMethodConsumer/multiRbusOpenMethodConsumer.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
         printf("multiRbusOpenMethodConsumer: rbusMethod_Invoke(Device.Methods.SimpleMethod()) using handle1 return err:%d\n", rc1);
     }
     rc2 = rbusMethod_Invoke(handle2, "Device.Methods.SimpleMethod()", inParams2, &outParams2);
-    if(rc1 != RBUS_ERROR_SUCCESS)
+    if(rc2 != RBUS_ERROR_SUCCESS)
     {
         printf("multiRbusOpenMethodConsumer: rbusMethod_Invoke(Device.Methods.SimpleMethod()) using handle2 return err:%d\n", rc2);
     }
@@ -135,15 +135,13 @@ int main(int argc, char *argv[])
     }
 
     rc2 = rbusMethod_Invoke(handle2, "Device.Methods.SimpleMethod1()", NULL, &outParams2);
-    if(rc1 != RBUS_ERROR_SUCCESS)
+    if(rc2 != RBUS_ERROR_SUCCESS)
     {
-        printf("DEEPAK multiRbusOpenMethodConsumer: rbusMethod_Invoke(Device.Methods.SimpleMethod1()) using handle2 %s:%d\n",
+        printf("multiRbusOpenMethodConsumer: rbusMethod_Invoke(Device.Methods.SimpleMethod1()) using handle2 %s:%d\n",
                              rc2 == RBUS_ERROR_SUCCESS ? "success" : "fail",rc2);
     } 
-    printf("multiRbusOpenMethodConsumer: rbusMethod_Invoke(Device.Methods.SimpleMethod1()) using handle2 %s:%d\n",
-        rc2 == RBUS_ERROR_SUCCESS ? "success" : "fail",rc2);
 
-    if(rc1 != RBUS_ERROR_SUCCESS)
+    if(rc1 != RBUS_ERROR_INVALID_HANDLE && rc1 != RBUS_ERROR_SUCCESS)
     {
         rbusObject_fwrite(outParams1, 1, stdout);
         rbusObject_Release(outParams1);


### PR DESCRIPTION
RDKB-51761 Test scenario to cover multiple rbus_open() call

Reason for change: Fixing intermittent crash in multiRbusOpenMethodConsumer
Test Procedure: Start rtrouted and ./rbus_test.sh or verify .github/workflows/unit_tests.yml 
Risks: Medium
Priority: P1