### PR TITLE
RDKB-52350:Gateway Manager gets stuck & XLE fails to do GFO or Restore

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1773,7 +1773,7 @@ int main(int argc, char* argv[])
     rtLog_Warn("another instance of rtrouted is already running");
     exit(12);
   }
-  mkdir("/tmp/.rbus", 0666);
+  mkdir("/tmp/.rbus", 0755);
 #ifdef ENABLE_RDKLOGGER
     rdk_logger_init("/etc/debug.ini");
 #endif


### PR DESCRIPTION
Reason for change: Because of a permissions issue with the /tmp/.rbus directory, the provider is unable to access the subscribers' component ID file. 
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com