### PR TITLE
LTE-2047 [AUTO][Release][6.7]Observed cellularmanager crash with signature 85788042 and reason as SIGSEGV /SEGV_MAPERR after 3 days of uptime

### DIFF
--- a/src/rtmessage/rtHashMap.c
+++ b/src/rtmessage/rtHashMap.c
@@ -49,6 +49,8 @@ struct _rtHashMap
 
 static rtVector rtHashMap_GetBucket(rtHashMap hashmap, const void* key)
 {
+    if(!rtVector_Size(hashmap->buckets))
+        return NULL;
     uint32_t hash = hashmap->key_hasher(hashmap, key);
     if(rtVector_Size(hashmap->buckets) > (size_t)hash)
         return rtVector_At(hashmap->buckets, hash);


### PR DESCRIPTION
LTE-2047 [AUTO][Release][6.7]Observed cellularmanager crash with signature 85788042 and reason as SIGSEGV /SEGV_MAPERR after 3 days of uptime

Reason for change: Observed cellularmanager crash with signature 85788042 and reason as SIGSEGV /SEGV_MAPERR after 3 days of uptime Test Procedure: Testing mentioned in Jira description
                1)XLE is with flashed with 6.7p1s6 release build
                2)XB is flashed with 6.2p26s1 release build
                3)XLE is an extender connected to XB via wifiBH
                4)2 clients connected to the setup
Risks: Low
Priority: P1