### PR TITLE
RDKB-52662 Update the multi rbusopen Tests

### DIFF
--- a/test/rbus/multiRbusOpenConsumer/rbusOpenSubRbusOpenConsumer.c
+++ b/test/rbus/multiRbusOpenConsumer/rbusOpenSubRbusOpenConsumer.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
     rbusFilter_Release(filter);
 
     sleep(25);
-
+    printf("consumer: exit\n");
     return rc;
 }
 

--- a/test/rbus/multiRbusOpenRbusGetProvider/multiRbusOpenRbusGetProvider.c
+++ b/test/rbus/multiRbusOpenRbusGetProvider/multiRbusOpenRbusGetProvider.c
@@ -137,8 +137,7 @@ rbusError_t multiRbusProvider_SampleDataSetHandler(rbusHandle_t handle, rbusProp
         }
         else
         {
-            rbusProperty_SetValue(prop, value);
-            //printf("%s Called Set handler with value = %d\n", name, rbusValue_GetInt32(value));
+            printf("%s Called Set handler with value = %d\n", name, rbusValue_GetInt32(value));
         }
     }
 


### PR DESCRIPTION
RDKB-52662 Update the multi rbusopen Tests

Reason for change: Fix for multiRbusOpenRbusGetProvider crash on device
Test Procedure: Start rtrouted and ./rbus_test.sh OR verify with unit_test.yml
Risks: Medium
Priority: P1