### PR TITLE
RDKB-53701: Fix unittest failure in rbus_gtest binary

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -91,6 +91,14 @@ jobs:
           export LD_LIBRARY_PATH=$PREFIX/lib
           nohup ./bin/multiRbusOpenRbusGetProvider >/tmp/log_multiRbusOpenRbusSetProvider.txt &
           ./bin/multiRbusOpenRbusSetConsumer
+      - name: Run Gtest Cases
+        run: |
+          cd build/rbus
+          nohup ./src/session_manager/rbus_session_mgr &
+          ./unittests/rbus_gtest.bin
+      - name: Stop SessionManager
+        run: |
+          killall -9 rbus_session_mgr
       - name: Stop rtrouted
         run: |
           killall -9 rtrouted

--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -28,8 +28,10 @@ GTEST_API_ int main(int argc, char* argv[])
 
   ret = RUN_ALL_TESTS();
 
-  if(ret)
+  if(ret){
       printf("Gtest returned with error : %d !!!\n",ret);
+      return -1;
+  }
 
   return 0;
 }

--- a/unittests/rbusApiNegTest.cpp
+++ b/unittests/rbusApiNegTest.cpp
@@ -103,7 +103,7 @@ TEST(rbusregDataNegTest, test1)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbus_regDataElements(handle, 1, NULL);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -131,7 +131,7 @@ TEST(rbusregDataNegTest, test3)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbus_regDataElements(handle, 0, dataElements);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -142,7 +142,7 @@ TEST(rbusUnregDataNegTest, test1)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc=rbus_unregDataElements(handle, 1, NULL);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -157,7 +157,7 @@ TEST(rbusUnregDataNegTest, test2)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc=rbus_unregDataElements(handle, 0, dataElements);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -347,7 +347,7 @@ TEST(rbusSetNegTest, test1)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbus_set(handle, "test.params", value, NULL);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -360,7 +360,7 @@ TEST(rbusSetNegTest, test2)
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rbusValue_Init(&value);
     rc = rbus_set(handle, NULL, value, NULL);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     rbusValue_Release(value);
     free(handle);
 }
@@ -577,7 +577,7 @@ TEST(rbusSubsNegTest, test1)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_Subscribe(handle,"Device.rbusProvider.", NULL, userData, 30);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -590,7 +590,7 @@ TEST(rbusSubsNegTest, test2)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_Subscribe(handle, NULL, handler, userData, 30);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -614,7 +614,7 @@ TEST(rbusSubAsyncNegTest, test1)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_SubscribeAsync(handle, "Device.rbusProvider.", handler, NULL, userData, 30);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -626,7 +626,7 @@ TEST(rbusSubAsyncNegTest, test2)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_SubscribeAsync(handle, "Device.rbusProvider.", NULL,subscribeHandler, userData, 30);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -639,7 +639,7 @@ TEST(rbusSubAsyncNegTest, test3)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_SubscribeAsync(handle, NULL, handler,subscribeHandler, userData, 30);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -721,7 +721,7 @@ TEST(rbusUnsubNegTest, test2)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_Unsubscribe(handle, NULL);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -784,7 +784,7 @@ TEST(rbusSubExNegTest, test2)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_SubscribeEx(handle, &subscription, 0, 0);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(eventReceiveHandler);
     free(handle);
 }
@@ -796,7 +796,7 @@ TEST(rbusSubExNegTest, test3)
 
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusEvent_SubscribeEx(handle, NULL, 1, 0);
-    EXPECT_EQ(rc,RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc,RBUS_ERROR_INVALID_HANDLE);
     free(handle);
 }
 
@@ -974,7 +974,7 @@ TEST(rbusInvokeAsyncNegTest, test2)
     rbusObject_Init(&inParams, NULL);
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusMethod_InvokeAsync(handle, NULL, inParams, asyncMethodHandler, 0);
-    EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc, RBUS_ERROR_INVALID_HANDLE);
     rbusObject_Release(inParams);
     free(handle);
 }
@@ -988,7 +988,7 @@ TEST(rbusInvokeAsyncNegTest, test3)
     rbusObject_Init(&inParams, NULL);
     handle = (struct _rbusHandle *) malloc(sizeof(struct _rbusHandle));
     rc = rbusMethod_InvokeAsync(handle, "Device.Methods.AsyncMethod()", inParams, NULL, 0);
-    EXPECT_EQ(rc, RBUS_ERROR_INVALID_INPUT);
+    EXPECT_EQ(rc, RBUS_ERROR_INVALID_HANDLE);
     rbusObject_Release(inParams);
     free(handle);
 }

--- a/unittests/rbusConsumer.cpp
+++ b/unittests/rbusConsumer.cpp
@@ -97,14 +97,22 @@ static int exec_rbus_get_test(rbusHandle_t handle, const char *param)
     struct tm compileTime;
     struct tm checkTime;
     rbusDateTime_t *rcTime = NULL;
+    char CHECK_TIME[20];
+    char COMPILE_TIME[20];
 
     rcTime = (rbusDateTime_t *)rbusValue_GetTime(val);
     getCompileTime(&compileTime);
+    strftime(COMPILE_TIME, sizeof(COMPILE_TIME), "%x - %I:%M%p", &compileTime);
+    printf("Formatted date & time : %s\n", COMPILE_TIME );
 
     rbusValue_UnMarshallRBUStoTM(&checkTime, rcTime);
+    strftime(CHECK_TIME, sizeof(CHECK_TIME), "%x - %I:%M%p", &checkTime);
+    printf("Formatted date & time : %s\n", CHECK_TIME );
 
-    rc = (mktime(&compileTime) == mktime(&checkTime)) ? RBUS_ERROR_SUCCESS : RBUS_ERROR_BUS_ERROR;
-
+    if(strcmp(COMPILE_TIME, CHECK_TIME)==0)
+	    rc = RBUS_ERROR_SUCCESS;
+    else
+	    rc = RBUS_ERROR_BUS_ERROR;
   } else if((0 == strcmp(param,"Device.rbusProvider.Object")) && (RBUS_OBJECT == type)) {
 
     rbusObject_t obj = rbusValue_GetObject(val);

--- a/unittests/rbus_unit_test_server.cpp
+++ b/unittests/rbus_unit_test_server.cpp
@@ -624,11 +624,6 @@ TEST_F(TestServer, rbus_registerObjBoundaryNegative_test1)
        EXPECT_EQ(err, RBUSCORE_SUCCESS) << "rbus_registerObj failed";
     }
 
-    memset( buffer, 0, DEFAULT_RESULT_BUFFERSIZE );
-    snprintf(buffer, (sizeof(buffer) - 1), "%s_%d", obj_name, i);
-    //printf("Registering object %s \n", buffer);
-    err = rbus_registerObj(buffer, callback, NULL);
-    EXPECT_EQ(err, RBUSCORE_ERROR_GENERAL) << "rbus_registerObj failed";
     for(i = 2; i <= 63; i++)
     {
        memset( buffer, 0, DEFAULT_RESULT_BUFFERSIZE );


### PR DESCRIPTION
Reason for change: Fix unittest cases failure
Test Procedure: Run rtrouted, rbus_session_mgr and rbus_gtest.bin
Risks: Medium
Priority: P1