### PR TITLE
RDKB-54115: Addressing segmentation fault in rbus_gtest binary

### DIFF
--- a/unittests/rbus_unit_test_server.cpp
+++ b/unittests/rbus_unit_test_server.cpp
@@ -1189,7 +1189,7 @@ TEST_F(TestServer, rtmsg_rtMessage_SetMessage_test1)
     rtMessage req = NULL, msg = NULL;
     rtMessage item, p;
     char* s = NULL;
-    char val;
+    char val[10];
     uint32_t n = 0;
     uint32_t size = 0;
     rtError err;
@@ -1218,7 +1218,7 @@ TEST_F(TestServer, rtmsg_rtMessage_SetMessage_test1)
     //Neg test passing invalid param
     err = rtMessage_GetMessageItem(item, "params", j, &p);
     EXPECT_EQ(err, RT_PROPERTY_NOT_FOUND) << "rtMessage_GetMessageItem failed";
-    err = rtMessage_GetStringValue(req, "method", &val, 10);
+    err = rtMessage_GetStringValue(req, "method", val, 10);
     EXPECT_EQ(err, RT_OK) << "rtMessage_GetStringValue failed";
     //Neg test passing invalid param
     err = rtMessage_SetMessage(NULL, "params", item);


### PR DESCRIPTION
Reason for change: run rbus_gtest.bin on device
Test Procedure: Test and verified
Risks: Medium
Priority: P1