### PR TITLE
RDKB-54519: RBUS - rbusValue_ToString converts parameter boolean value into "true/false" strings

### DIFF
--- a/src/rbus/rbus_value.c
+++ b/src/rbus/rbus_value.c
@@ -260,7 +260,7 @@ char* rbusValue_ToString(rbusValue_t v, char* buf, size_t buflen)
             n = (2 * v->d.bytes->posWrite) + 1;
             break;
         case RBUS_BOOLEAN:
-            n = snprintf(p, 0, "%d", (int)v->d.b)+1;
+            n = snprintf(p, 0, "%s", (int)v->d.b ? "true" : "false")+1;
             break;
         case RBUS_INT32:
             n = snprintf(p, 0, "%d", v->d.i32)+1;
@@ -322,7 +322,7 @@ char* rbusValue_ToString(rbusValue_t v, char* buf, size_t buflen)
         break;
     }
     case RBUS_BOOLEAN:
-        snprintf(p, n, "%d", (int)v->d.b);
+        snprintf(p, n, "%s", (int)v->d.b ? "true" : "false");
         break;
     case RBUS_INT32:
         snprintf(p, n, "%d", v->d.i32);

--- a/test/rbus/consumer/valueAPI.c
+++ b/test/rbus/consumer/valueAPI.c
@@ -1000,7 +1000,7 @@ void testValue_ToString()
         
     rbusValue_SetBoolean(v, true);
     s = rbusValue_ToString(v,0,0);
-    TEST(!strcmp(s, "1"));
+    TEST(!strcmp(s, "true"));
     free(s);
 
     rbusValue_SetChar(v, 'a');
@@ -1120,7 +1120,7 @@ void testValue_ToDebugString()
 
     rbusValue_SetBoolean(v, true);
     s = rbusValue_ToDebugString(v,0,0);
-    TEST(!strcmp(s, "rbusValue type:RBUS_BOOLEAN value:1"));
+    TEST(!strcmp(s, "rbusValue type:RBUS_BOOLEAN value:true"));
     free(s);
 
     rbusValue_SetChar(v, 'a');

--- a/unittests/rbusValueTest.cpp
+++ b/unittests/rbusValueTest.cpp
@@ -113,9 +113,9 @@ static void exec_validate_test(rbusValueType_t type,char *buffer)
   pRet = rbusValue_ToString(val, NULL, 0);
   if(type == RBUS_BOOLEAN) {
     if(strcmp(buffer,"true") == 0)
-      EXPECT_STREQ(pRet,"1");
+      EXPECT_STREQ(pRet,"true");
     if(strcmp(buffer,"false") == 0)
-      EXPECT_STREQ(pRet,"0");
+      EXPECT_STREQ(pRet,"false");
   } else if(type == RBUS_BYTE) {
       char tmp[4] = {0};
       sprintf(tmp,"%x",buffer[0]);
@@ -141,9 +141,9 @@ static void exec_validate_test(rbusValueType_t type,char *buffer)
     len = strlen(pRet);
     if(type == RBUS_BOOLEAN) {
       if(strcmp(buffer,"true") == 0)
-        EXPECT_EQ(strncmp(pRet,"1",len-1),0);
+        EXPECT_EQ(strncmp(pRet,"true",len-1),0);
       if(strcmp(buffer,"false") == 0)
-        EXPECT_EQ(strncmp(pRet,"0",len-1),0);
+        EXPECT_EQ(strncmp(pRet,"false",len-1),0);
     } else if(type == RBUS_BYTE) {
       char tmp[4] = {0};
       sprintf(tmp,"%x",buffer[0]);


### PR DESCRIPTION
Reason for change: rbusValue_ToString functions converts in parameter Boolean type value into "true/false" strings
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com