### PR TITLE
RDKB-54362: Fix Memory Leak in sampleApps, testsuites and gtest cases

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1522,8 +1522,8 @@ static void master_event_callback(rtMessageHeader const* hdr, uint8_t const* dat
     }
     /* If no matching objects exist in records. Create a new entry.*/
     unlock();
-    rbusMessage_Release(msg);
     RBUSCORELOG_WARN("Received event %s::%s for which no subscription exists.", sender, event_name);
+    rbusMessage_Release(msg);
     return;
 }
 

--- a/src/rbus/CMakeLists.txt
+++ b/src/rbus/CMakeLists.txt
@@ -57,3 +57,7 @@ install (TARGETS rbus
 
 install (DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION "include/rbus")
 
+if (MSG_ROUNDTRIP_TIME)
+  message("Message rountrip time calculation enabled")
+  add_definitions(-DMSG_ROUNDTRIP_TIME=1)
+endif (MSG_ROUNDTRIP_TIME)

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1386,6 +1386,8 @@ static int _master_event_callback_handler(char const* sender, char const* eventN
     {
         RBUSLOG_DEBUG("Received master event callback: sender=%s eventName=%s, but no subscription found", sender, event.name);
         HANDLE_EVENTSUBS_MUTEX_UNLOCK(handleInfo);
+        if(event.data)
+            rbusObject_Release(event.data);
         return RBUSCORE_ERROR_EVENT_NOT_HANDLED;
     }
 exit_1:
@@ -2537,8 +2539,8 @@ static void _subscribe_callback_handler (rbusHandle_t handle, rbusMessage reques
                                                            rbusEvent_SubscribeWithRetries() function call */
                     rbusEventData_appendToMessage(&event, filter, interval, duration, handleInfo->componentId, *response);
                     rbusProperty_Release(tmpProperties);
-                    rbusObject_Release(data);
                 }
+                rbusObject_Release(data);
             }
             if(payload)
             {
@@ -3510,6 +3512,7 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
                                     }
                                 }
                             }
+                            rbusProperty_Release(tmpProperties);
                         }
                     }
                     if (errorcode != RBUS_ERROR_SUCCESS)
@@ -4820,6 +4823,8 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
             {
                 RBUSLOG_WARN("EVENT_SUBSCRIPTION_FAIL_INVALID_INPUT  %s", eventName);/*RDKB-33658-AC9*/
                 rbusEventSubscription_free(sub);
+                if(response)
+                    rbusMessage_Release(response);
                 return providerError;
             }
         }

--- a/src/rbus/rbus_asyncsubscribe.c
+++ b/src/rbus/rbus_asyncsubscribe.c
@@ -177,7 +177,7 @@ static void rbusAsyncSubscribeRetrier_SendSubscriptionRequests()
             rbusCoreError_t coreerr;
             int elapsed;
             int providerError;
-            rbusMessage response;
+            rbusMessage response = NULL;
             uint32_t subscriptionId = 0;
 
 
@@ -230,6 +230,8 @@ static void rbusAsyncSubscribeRetrier_SendSubscriptionRequests()
                         rbusMessage_GetUInt32(response, &subscriptionId);
                     RBUSLOG_INFO("%s subscribe retries succeeded", item->subscription->eventName);
                     responseErr = RBUS_ERROR_SUCCESS;
+                    if(response)
+                        rbusMessage_Release(response);
                 }
                 else
                 {
@@ -250,6 +252,8 @@ static void rbusAsyncSubscribeRetrier_SendSubscriptionRequests()
                         RBUSLOG_INFO("%s subscribe retries failed due to core error %d", item->subscription->eventName, coreerr);
                         responseErr = RBUS_ERROR_BUS_ERROR;
                     }
+                    if(response)
+                        rbusMessage_Release(response);
                 }
 
                 _subscribe_async_callback_handler(item->subscription->handle, item->subscription, responseErr, subscriptionId);

--- a/test/rbus/consumer/methods.c
+++ b/test/rbus/consumer/methods.c
@@ -331,6 +331,8 @@ void testMethods(rbusHandle_t handle, int* countPass, int* countFail)
 
     rbusObject_Release(inParams);
 
+    if(outParams)
+       rbusObject_Release(outParams);
     /*cleanup*/
     rbusTable_removeRow(handle, row2);
     rbusTable_removeRow(handle, row1);

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -33,7 +33,8 @@ if (NOT GTEST_INCLUDE_DIR)
 
     ExternalProject_Add(
       gtest
-      URL https://github.com/google/googletest/archive/master.zip
+      GIT_REPOSITORY    https://github.com/google/googletest.git
+      GIT_TAG           release-1.12.0
       PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
       INSTALL_COMMAND "")
 

--- a/unittests/rbusProvider.cpp
+++ b/unittests/rbusProvider.cpp
@@ -85,12 +85,11 @@ rbusError_t getVCHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHa
 
     rbusValue_SetInt32(value, mydata);
   } else if(strcmp("Device.rbusProvider.DateTime",name) == 0) {
-    rbusDateTime_t timeVal;
-    memset(&timeVal,0,sizeof(timeVal));
     struct tm compileTime;
     getCompileTime(&compileTime);
-    memcpy(&(timeVal.m_time), &compileTime, sizeof(struct tm));
-    rbusValue_SetTime(value, &(timeVal));
+    rbusDateTime_t tv1;
+    rbusValue_MarshallTMtoRBUS(&tv1, &compileTime);
+    rbusValue_SetTime(value, &(tv1));
   } else if(strcmp("Device.rbusProvider.Object",name) == 0) {
     rbusObject_t obj = NULL;
     rbusObject_Init(&obj, name);


### PR DESCRIPTION
Reason for change: Fix Memory leak in rbus code.
Test Procedure: Test and verified with rbuscli and testapp.
Risks: Medium
Priority: P1