### PR TITLE
Fix: Modifying Error Codes in RBUS Core

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -762,7 +762,7 @@ static rbusCoreError_t send_subscription_request(const char * object_name, const
         else
             rbusMessage_Release(internal_response);
     }
-    else if(RBUSCORE_ERROR_DESTINATION_UNREACHABLE == ret)
+    else if(RBUSCORE_ERROR_ENTRY_NOT_FOUND == ret)
     {
         RBUSCORELOG_DEBUG("Error %s subscription for %s::%s. Provider not found. %d", (activate? "adding" : "removing"), object_name, event_name, ret);
         //keep ret as RBUSCORE_ERROR_DESTINATION_UNREACHABLE
@@ -1141,7 +1141,7 @@ rbusCoreError_t rbus_invokeRemoteMethod2(rtConnection myConn, const char * objec
         if(RT_OBJECT_NO_LONGER_AVAILABLE == err)
         {
             RBUSCORELOG_DEBUG("Cannot reach object %s.", object_name);
-            ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+            ret = RBUSCORE_ERROR_ENTRY_NOT_FOUND;
         }
         else if(RT_ERROR_TIMEOUT == err)
         {

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -183,6 +183,9 @@ static rbusError_t rbusCoreError_to_rbusError(rtError e)
     case RBUSCORE_ERROR_SUBSCRIBE_NOT_HANDLED:
       err = RBUS_ERROR_INVALID_OPERATION;
       break;
+    case RBUSCORE_ERROR_ENTRY_NOT_FOUND:
+      err = RBUS_ERROR_DESTINATION_NOT_FOUND;
+      break;
     default:
       err = RBUS_ERROR_BUS_ERROR;
       break;
@@ -4615,7 +4618,7 @@ static rbusError_t _rbus_event_unsubscribe(
 
     if(coreerr != RBUSCORE_SUCCESS)
     {
-        if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE)
+        if(coreerr == RBUSCORE_ERROR_ENTRY_NOT_FOUND)
         {
             subInternal->dirty = true;
             RBUSLOG_DEBUG ("n%s unsubscription failed because no provider could be found"
@@ -4721,7 +4724,7 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
 
         coreerr = rbus_subscribeToEventTimeout(NULL, sub->eventName, _event_callback_handler, payload, sub, &providerError, destNotFoundTimeout, publishOnSubscribe, &response, rawData);
         
-        if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE && destNotFoundTimeout > 0)
+        if(coreerr == RBUSCORE_ERROR_ENTRY_NOT_FOUND && destNotFoundTimeout > 0)
         {
             int sleepTime = destNotFoundSleep;
 
@@ -4785,7 +4788,7 @@ static rbusError_t rbusEvent_SubscribeWithRetries(
     }
     else
     {
-        if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE)
+        if(coreerr == RBUSCORE_ERROR_ENTRY_NOT_FOUND)
         {
             RBUSLOG_DEBUG("%s all subscribe retries failed because no provider could be found", eventName);
             RBUSLOG_WARN("EVENT_SUBSCRIPTION_FAIL_NO_PROVIDER_COMPONENT  %s", eventName);/*RDKB-33658-AC7*/
@@ -5044,7 +5047,7 @@ rbusError_t rbusEvent_Unsubscribe(
         else
         {
             
-            if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE)
+            if(coreerr == RBUSCORE_ERROR_ENTRY_NOT_FOUND)
             {
                 subInternal->dirty = true;
                 RBUSLOG_INFO ("%s unsubscription failed because no provider could be found"

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3998,7 +3998,7 @@ rbusError_t rbus_setMulti(rbusHandle_t handle, int numProps, rbusProperty_t prop
         }
         else
         {
-            errorcode = RBUS_ERROR_DESTINATION_NOT_REACHABLE;
+            errorcode = RBUS_ERROR_DESTINATION_NOT_FOUND;
             RBUSLOG_ERROR("Discover component names failed with error %d and counts %d/%d", errorcode, numProps, numComponents);
             for(i = 0; i < numComponents; i++)
             {

--- a/src/rbus/rbus_asyncsubscribe.c
+++ b/src/rbus/rbus_asyncsubscribe.c
@@ -190,7 +190,7 @@ static void rbusAsyncSubscribeRetrier_SendSubscriptionRequests()
 
             elapsed = rtTime_Elapsed(&item->startTime, &now);
 
-            if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE &&  /*the only error that means provider not found yet*/
+            if(coreerr == RBUSCORE_ERROR_ENTRY_NOT_FOUND &&  /*the only error that means provider not found yet*/
              elapsed < rbusConfig_Get()->subscribeTimeout)    /*if we haven't timeout out yet*/
             {
                 if(item->nextWaitTime == 0)
@@ -235,7 +235,7 @@ static void rbusAsyncSubscribeRetrier_SendSubscriptionRequests()
                 }
                 else
                 {
-                    if(coreerr == RBUSCORE_ERROR_DESTINATION_UNREACHABLE)
+                    if(coreerr == RBUSCORE_ERROR_ENTRY_NOT_FOUND)
                     {
                         RBUSLOG_INFO("%s all subscribe retries failed and no provider found", item->subscription->eventName);
                         RBUSLOG_WARN("EVENT_SUBSCRIPTION_FAIL_NO_PROVIDER_COMPONENT  %s", item->subscription->eventName);/*RDKB-33658-AC7*/

--- a/test/rbus/consumer/methods.c
+++ b/test/rbus/consumer/methods.c
@@ -321,7 +321,7 @@ void testMethods(rbusHandle_t handle, int* countPass, int* countFail)
      */
     printf("\n##########################################\n# TEST rbusMethod_InvokeAsync(%s) \n#\n", "Device.TestProvider.ShouldNotExist()");
     asyncCalled = false;
-    asyncError = RBUS_ERROR_DESTINATION_NOT_REACHABLE;
+    asyncError = RBUS_ERROR_DESTINATION_NOT_FOUND;
     err = rbusMethod_InvokeAsync(handle, "Device.TestProvider.ShouldNotExist()", inParams, asyncMethodHandler1, 0);
     printf("consumer: rbusMethod_InvokeAsync(%s) %s\n", "Device.TestProvider.ShouldNotExist()",
         err == RBUS_ERROR_SUCCESS ? "success" : "fail");

--- a/unittests/rbusApiNegTest.cpp
+++ b/unittests/rbusApiNegTest.cpp
@@ -944,7 +944,7 @@ TEST(rbusInvokeNegTest, test3)
 
     rbusObject_Init(&inParams, NULL);
     rc = rbusMethod_Invoke(handle, method, inParams, &outParams);
-    EXPECT_EQ(rc, RBUS_ERROR_DESTINATION_NOT_REACHABLE);
+    EXPECT_EQ(rc, RBUS_ERROR_DESTINATION_NOT_FOUND);
     if(outParams)
         rbusObject_Release(outParams);
     if(inParams)

--- a/unittests/rbusFunctionalityTest.cpp
+++ b/unittests/rbusFunctionalityTest.cpp
@@ -131,7 +131,7 @@ static void exec_func_test(rbusGtest_t test)
           break;
         case RBUS_GTEST_SET_MULTI3:
         case RBUS_GTEST_SET3:
-          expected_consumer_status = RBUS_ERROR_DESTINATION_NOT_REACHABLE;
+          expected_consumer_status = RBUS_ERROR_DESTINATION_NOT_FOUND;
           break;
         case RBUS_GTEST_SET_MULTI5:
         case RBUS_GTEST_SET2:

--- a/unittests/rbus_unit_stresstest_server.cpp
+++ b/unittests/rbus_unit_stresstest_server.cpp
@@ -362,8 +362,8 @@ TEST_F(StressTestServer, dataPushPull_test3)
         sleep(2);
         conn_status = OPEN_BROKER_CONNECTION(client_name);
 
-        RBUS_PUSH_OBJECT(test_string, test_server_obj, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
-        RBUS_PULL_OBJECT(test_string, test_server_obj, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
+        RBUS_PUSH_OBJECT(test_string, test_server_obj, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
+        RBUS_PULL_OBJECT(test_string, test_server_obj, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
 
         if(conn_status)
             CLOSE_BROKER_CONNECTION();
@@ -1186,8 +1186,8 @@ TEST_F(StressTestServer, rbus_removeElement_test1)
 
         for(i = 0; i < 100; i++)
         {
-            RBUS_PUSH_OBJECT(test_string, server_element, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
-            RBUS_PULL_OBJECT(test_string, server_element, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
+            RBUS_PUSH_OBJECT(test_string, server_element, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
+            RBUS_PULL_OBJECT(test_string, server_element, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
         }
 
         if(conn_status)

--- a/unittests/rbus_unit_test_client.cpp
+++ b/unittests/rbus_unit_test_client.cpp
@@ -215,7 +215,7 @@ rbusCoreError_t CREATE_SESSION()
     }
     else{
         printf("RPC with session manager failed.\n");
-        ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+        ret = RBUSCORE_ERROR_ENTRY_NOT_FOUND;
         rbusMessage_Release(response);
         return ret;
     }
@@ -255,7 +255,7 @@ rbusCoreError_t PRINT_CURRENT_SESSION_ID()
     }
     else{
         printf("RPC with session manager failed.\n");
-        ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+        ret = RBUSCORE_ERROR_ENTRY_NOT_FOUND;
         rbusMessage_Release(response);
         return ret;
     }
@@ -293,7 +293,7 @@ rbusCoreError_t END_SESSION(int session)
     }
     else{
         printf("RPC with session manager failed.\n");
-        ret = RBUSCORE_ERROR_DESTINATION_UNREACHABLE;
+        ret = RBUSCORE_ERROR_ENTRY_NOT_FOUND;
         rbusMessage_Release(response);
         return ret;
     }

--- a/unittests/rbus_unit_test_event_client.cpp
+++ b/unittests/rbus_unit_test_event_client.cpp
@@ -147,7 +147,7 @@ TEST_F(EventClientAPIs, rbus_subscribeToEvent_test1)
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Test with invalid objname passed
      err = rbus_subscribeToEvent(NULL, "event_1", &event_callback, NULL, NULL, NULL);
-     ASSERT_EQ(err,RBUSCORE_ERROR_DESTINATION_UNREACHABLE) << "rbus_subscribeToEvent failed";
+     ASSERT_EQ(err,RBUSCORE_ERROR_ENTRY_NOT_FOUND) << "rbus_subscribeToEvent failed";
     //Test with the event name  to be NULL
      err = rbus_subscribeToEvent(obj_name, "NULL", &event_callback, NULL, NULL, NULL);
      ASSERT_EQ(err,RBUSCORE_ERROR_GENERAL) << "rbus_subscribeToEvent failed";
@@ -212,7 +212,7 @@ TEST_F(EventClientAPIs, rbus_subscribeToEventTimeout_test2)
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Test with invalid objname passed
     err = rbus_subscribeToEventTimeout(NULL, "event_1", &event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
-    ASSERT_EQ(err,RBUSCORE_ERROR_DESTINATION_UNREACHABLE) << "rbus_subscribeToEventTimeout failed";
+    ASSERT_EQ(err,RBUSCORE_ERROR_ENTRY_NOT_FOUND) << "rbus_subscribeToEventTimeout failed";
     //Test with the event name  to be NULL
     err = rbus_subscribeToEventTimeout(obj_name, "NULL", &event_callback, NULL, NULL, NULL, 1000, false, NULL, false);
     ASSERT_EQ(err,RBUSCORE_ERROR_GENERAL) << "rbus_subscribeToEventTimeout failed";
@@ -258,7 +258,7 @@ TEST_F(EventClientAPIs, rbus_unsubscribeFromEvent_test1)
     ASSERT_EQ(conn_status, true) << "RBUS_OPEN_BROKER_CONNECTION failed";
     //Test with objname to be NULL
     err = rbus_unsubscribeFromEvent(NULL, "event_1", NULL, false);
-    ASSERT_EQ(err,RBUSCORE_ERROR_DESTINATION_UNREACHABLE) << "rbus_unsubscribeFromEvent failed";
+    ASSERT_EQ(err,RBUSCORE_ERROR_ENTRY_NOT_FOUND) << "rbus_unsubscribeFromEvent failed";
    //Test with the event name  to be NULL
     err = rbus_unsubscribeFromEvent(obj_name, NULL, NULL, false);
     ASSERT_EQ(err,RBUSCORE_ERROR_GENERAL) << "rbus_unsubscribeFromEvent failed";

--- a/unittests/rbus_unit_test_multiple_objects.cpp
+++ b/unittests/rbus_unit_test_multiple_objects.cpp
@@ -631,10 +631,10 @@ TEST_F(MultipleObjectsTest, DISABLED_rbus_multipleElement_test5)
         snprintf(name_buf, (sizeof(name_buf) - 1), "student_info.obj.element10");
         snprintf(data_buf, (sizeof(data_buf) - 1), "student_element10_data");
 
-//        RBUS_PUSH_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
+//        RBUS_PUSH_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
 
         /*Trying to pull data from an undefined element*/
-        RBUS_PULL_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
+        RBUS_PULL_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
 
         if(conn_status)
             CLOSE_BROKER_CONNECTION1();
@@ -672,10 +672,10 @@ TEST_F(MultipleObjectsTest, DISABLED_rbus_multipleElement_test6)
         snprintf(name_buf, (sizeof(name_buf) - 1), "student_info.obj.elementNone");
         snprintf(data_buf, (sizeof(data_buf) - 1), "student_data_none");
 
-        RBUS_PUSH_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
+        RBUS_PUSH_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
 
         /*Trying to pull data from an undefined element*/
-        RBUS_PULL_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_DESTINATION_UNREACHABLE);
+        RBUS_PULL_OBJECT1(data_buf, name_buf, RBUSCORE_ERROR_ENTRY_NOT_FOUND);
 
         if(conn_status)
             CLOSE_BROKER_CONNECTION1();


### PR DESCRIPTION
Reason for change: When an object not found error originates from rtrouted,
                   rbuscore returs error code RBUSCORE_ERROR_ENTRY_NOT_FOUND
                   instead of RBUSCORE_ERROR_DESTINATION_UNREACHABLE.
Signed-off-by: Netaji Panigrahi <Netaji_Panigrahi@comcast.com>