### PR TITLE
REFPLTB-3035: Memory leak in rbus "rbus_discoverRegisteredComponents"

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2297,7 +2297,6 @@ rbusCoreError_t rbus_discoverRegisteredComponents(int * count, char *** componen
         }
 
         rtMessage_Release(msg);
-        rtMessage_Release(out);
         ret = RBUSCORE_SUCCESS;
     }
     else
@@ -2305,7 +2304,8 @@ rbusCoreError_t rbus_discoverRegisteredComponents(int * count, char *** componen
         RBUSCORELOG_ERROR("Failed with error code %d", err);
         ret = RBUSCORE_ERROR_GENERAL;
     }
-    
+
+    rtMessage_Release(out);
     return ret;
 }
 


### PR DESCRIPTION
    Reason for change: Fix Memory leak in rbus code.
    Test Procedure: Test and verified with rbuscli.
    Risks: Medium
    Priority: P1

    Signed-off-by: Prabhudas Gannavarapu <prabhudas_gannavarapu@comcast.com>