### PR TITLE
RDKB-55966: "rbuscli get Device.WiFi." failed with Segmentation fault

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3494,7 +3494,7 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
                         }
                         else
                         {
-                            rbusProperty_t tmpProperties;
+                            rbusProperty_t tmpProperties = NULL;
 
                             if((errorcode = _getExt_response_parser(response, &tmpNumOfValues, &tmpProperties)) != RBUS_ERROR_SUCCESS)
                             {
@@ -3642,7 +3642,7 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
                     }
                     else
                     {
-                        rbusProperty_t batchResult;
+                        rbusProperty_t batchResult = NULL;
                         int batchNumVals;
                         if((errorcode = _getExt_response_parser(response, &batchNumVals, &batchResult)) != RBUS_ERROR_SUCCESS)
                         {


### PR DESCRIPTION
Reason for change: The crash occurred due to an invalid memory 
    access. The rbusProperty_Release() function is to release local 
    variables that have previously been freed. 
    To resolve the problem, the local variable was initialized with "NULL".         
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com