### PR TITLE
RDKBDEV-2829: fix GetParameterAttributes RPC

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2710,6 +2710,13 @@ static int _callback_handler(char const* destination, char const* method, rbusMe
     {
         _table_remove_row_callback_handler (handle, request, response);
     }
+    else if (!strcmp(method, METHOD_GETPARAMETERATTRIBUTES))
+    {
+        /* For the components register directly with rbus_open,
+         * return success for getAttributes with 0 parameters.*/
+        rbusMessage_Init(response);
+        rbusMessage_SetInt32(*response, RBUS_ERROR_SUCCESS);
+    }
     else if(!strcmp(method, METHOD_SUBSCRIBE) || !strcmp(method, METHOD_UNSUBSCRIBE))
     {
         _subscribe_callback_handler (handle, request, response, method);

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2715,7 +2715,7 @@ static int _callback_handler(char const* destination, char const* method, rbusMe
         /* For the components register directly with rbus_open,
          * return success for getAttributes with 0 parameters.*/
         rbusMessage_Init(response);
-        rbusMessage_SetInt32(*response, RBUS_ERROR_SUCCESS);
+        rbusMessage_SetInt32(*response, RBUS_ERROR_INVALID_METHOD);
     }
     else if(!strcmp(method, METHOD_SUBSCRIBE) || !strcmp(method, METHOD_UNSUBSCRIBE))
     {

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2715,7 +2715,7 @@ static int _callback_handler(char const* destination, char const* method, rbusMe
         /* For the components register directly with rbus_open,
          * return success for getAttributes with 0 parameters.*/
         rbusMessage_Init(response);
-        rbusMessage_SetInt32(*response, RBUS_ERROR_INVALID_METHOD);
+        rbusMessage_SetInt32(*response, RBUS_ERROR_SUCCESS);
     }
     else if(!strcmp(method, METHOD_SUBSCRIBE) || !strcmp(method, METHOD_UNSUBSCRIBE))
     {


### PR DESCRIPTION
Reason for change:
fix GetParameterAttributes RPC on root object returns fault code 9002 ( OFW-4277 )

Test Procedure: Sanity.
Risks: None.
Signed-off-by: anil shetty <adshetty@libertyglobal.com>