### PR TITLE
RDKBDEV-2830: fix memory leak in rbus_invokeRemoteMethod

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1115,8 +1115,6 @@ rbusCoreError_t rbus_invokeRemoteMethod2(rtConnection myConn, const char * objec
     char const *traceParent = NULL;
     char const *traceState = NULL;
 
-    rbus_getOpenTelemetryContext(&traceParent, &traceState);
-
     if(NULL == myConn)
     {
         RBUSCORELOG_ERROR("Not connected.");
@@ -1128,6 +1126,8 @@ rbusCoreError_t rbus_invokeRemoteMethod2(rtConnection myConn, const char * objec
         RBUSCORELOG_ERROR("Object name is too long.");
         return RBUSCORE_ERROR_INVALID_PARAM;
     }
+
+    rbus_getOpenTelemetryContext(&traceParent, &traceState);
 
     *in = NULL;
     if(NULL == out)
@@ -1181,6 +1181,7 @@ rbusCoreError_t rbus_invokeRemoteMethod2(rtConnection myConn, const char * objec
         rbusMessage_Release(*in);
         *in = NULL;
     }
+    rbus_releaseOpenTelemetryContext();
     return ret;
 }
 

--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1181,7 +1181,6 @@ rbusCoreError_t rbus_invokeRemoteMethod2(rtConnection myConn, const char * objec
         rbusMessage_Release(*in);
         *in = NULL;
     }
-    rbus_releaseOpenTelemetryContext();
     return ret;
 }
 


### PR DESCRIPTION
Reason for change:
1,024 bytes in 1 blocks are definitely lost in loss record 318 of 350 malloc (vg_replace_malloc.c:309)
rbus_getOpenTelemetryContextFromThreadLocal (rbuscore.c:2276) rbus_getOpenTelemetryContextFromThreadLocal (rbuscore.c:2269) rbus_getOpenTelemetryContext (rbuscore.c:2290)
rbus_invokeRemoteMethod (rbuscore.c:1064)

Test Procedure: Sanity.
Risks: None.