### PR TITLE
RDKC-15260 : XCAM2 devices failing to fetch the TR181 parameter value of Device.DeviceInfo.X_RDKCENTRAL-COM_MAC

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -1836,11 +1836,7 @@ static void * rtConnection_ReaderThread(void *data)
   while (1 == GetRunThreadsSync(con))
   {
     rtTime_Now(&con->reader_reconnect_time);
-    #ifdef WITH_SPAKE2
-    if((err = rtConnection_Read(con, 60000)) != RT_OK)
-    #else
     if((err = rtConnection_Read(con, -1)) != RT_OK)
-    #endif
     {
       if (0 == GetRunThreadsSync(con))
       {


### PR DESCRIPTION
Reason for change: select system call times out (after 60 seconds) and then enters a 5-second sleep. During this sleep period, rtrouted sends the provider details to telemetry2_0.
Test Procedure: none
Risks: Medium
Priority: P1

Signed-off-by: garumu177 <Gokulraj_Arumugam@comcast.com>