### PR TITLE
RBUS Events are not received if handle is closed and reopened.

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -682,6 +682,7 @@ rbusCoreError_t rbus_closeBrokerConnection()
         return RBUSCORE_ERROR_GENERAL;
     }
     g_connection = NULL;
+    g_run_event_client_dispatch = false;
     unlock();
 
     pthread_mutex_destroy(&g_mutex);


### PR DESCRIPTION
Event dispatch thread state is maintained in a static global variable. When rbus handle is shutdown, the state is never set to false, so any future handles opened will not receive events.

Reproduction steps:

- Open RBus Handle
- Register for event
- Close RBus Handle
- Open new RBus Handle
- Register for event

The process will not receive events, because the event dispatch thread is not started.