### PR TITLE
RDKBDEV-2974: fix rtrouted crash is seen with an invalid DML query

### DIFF
--- a/src/rtmessage/rtRoutingTree.c
+++ b/src/rtmessage/rtRoutingTree.c
@@ -110,15 +110,15 @@ static void freeTreeRoute(void* p)
 
 static void tokenizeExpression(const char* expression)
 {
-    int i = 0;
+    unsigned int i = 0;
     const char* from = expression;
     char* to = workBuffer;
     workTokenCount = 0;
-    while(*from)
+    while(*from && i < sizeof(workTokens)/sizeof(workTokens[0]))
     {
         workTokens[i].name = to;
         
-        while(*from && *from != '.')
+        while(*from && *from != '.' && to < (workBuffer + sizeof(workBuffer)/sizeof(workBuffer[0]) - 1))
             *to++ = *from++;
         workTokens[i].length = to - workTokens[i].name;
         *to++ = 0;


### PR DESCRIPTION
Reason for change:
When a dmcli query is made with a large number of dots, rtrouted crashes. For example: dmcli eRT getv Device.NAT.X_CISCO_COM_DMZ.InternalIP

The reason is that the tokenizeExpression function splits the datamodel path based on dots and writes into the workTokens array without checking the number of elements being written.
This causes a buffer overflow if the number of dots is more than the size of the workTokens array (32).
[Solution]
Add some checks in tokenizeExpression to avoid overflowing the workTokens and workBuffer arrays. Test Procedure:
Run 'dmcli eRT getv Device.NAT.X_CISCO_COM_DMZ.InternalIP' Verify that rtrouted doesn't crash
Run 'rbuscli get' with a path that's more than 512 characters in length Verify that rtrouted doesn't crash
Test Procedure: Sanity.
Risks: None.

Signed-off-by: Hamza Ben Zekri <hbenzekri@libertyglobal.com>