### PR TITLE
RDKCOM-5110 RDKBDEV-2975: fix error message typo

### DIFF
--- a/src/core/rbuscore_message.c
+++ b/src/core/rbuscore_message.c
@@ -38,7 +38,7 @@
     VERIFY_UNPACK_NEXT_ITEM()\
     if(message->upk.data.type != T)\
     {\
-        RBUSCORELOG_ERROR("%s unexpected date type %d", __FUNCTION__, message->upk.data.type);\
+        RBUSCORELOG_ERROR("%s unexpected data type %d", __FUNCTION__, message->upk.data.type);\
         return RT_FAIL;\
     }
 
@@ -46,7 +46,7 @@
     VERIFY_UNPACK_NEXT_ITEM()\
     if(message->upk.data.type != T && message->upk.data.type != T2)\
     {\
-        RBUSCORELOG_ERROR("%s unexpected date type %d", __FUNCTION__, message->upk.data.type);\
+        RBUSCORELOG_ERROR("%s unexpected data type %d", __FUNCTION__, message->upk.data.type);\
         return RT_FAIL;\
     }
 


### PR DESCRIPTION
Reason for change:
fix error message typo: rbuscore_message.c:204
rbusMessage_GetBytes unexpected date type 5 Update date -> data Test Procecedure: Sanity.
Risks: None.
Signed-off-by: mkamat <mkamat@libertyglobal.com>