### PR TITLE
RDKB-57423: Observed errors when ran valgrind for rbusTestConsumer -a

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3104,6 +3104,8 @@ rbusError_t rbus_close(rbusHandle_t handle)
 
     componentName = handleInfo->componentName;
     handleInfo->componentName=NULL;
+    ERROR_CHECK(pthread_mutex_destroy(&handleInfo->handle_eventSubsMutex));
+    ERROR_CHECK(pthread_mutex_destroy(&handleInfo->handle_subsMutex));
     rbusHandleList_Remove(handleInfo);
 
     if(rbusHandleList_IsEmpty())
@@ -3126,8 +3128,6 @@ rbusError_t rbus_close(rbusHandle_t handle)
 
         _rbus_open_pre_initialize(false);
     }
-    ERROR_CHECK(pthread_mutex_destroy(&handleInfo->handle_eventSubsMutex));
-    ERROR_CHECK(pthread_mutex_destroy(&handleInfo->handle_subsMutex));
 
     UnlockMutex();
 


### PR DESCRIPTION
Reason for change: Fixed errors when ran valgrind for rbusTestConsumer -a
Test Procedure: run rbusTestConsumer with valgrind
Risks: None.