### PR TITLE
rtmessage: add missing mutex unlock at early exit rtThreadPool

### DIFF
--- a/src/rtmessage/rtThreadPool.c
+++ b/src/rtmessage/rtThreadPool.c
@@ -304,7 +304,10 @@ rtError rtThreadPool_RunTask(rtThreadPool pool, rtThreadPoolFunc func, void* use
   {
     task = rt_try_malloc(sizeof(struct _rtThreadTask));
     if(!task)
+    {
+      pthread_mutex_unlock(&pool->poolLock);
       return rtErrorFromErrno(ENOMEM);
+    }
     rtLog_Debug("taskList data null so alloc new %p", (void*)task);
     rtListItem_SetData(item, task);
   }
@@ -321,7 +324,10 @@ rtError rtThreadPool_RunTask(rtThreadPool pool, rtThreadPoolFunc func, void* use
   {
     rtLog_Debug("%s creating new thread", __FUNCTION__);
     if((err = rtThreadPool_CreateWorkerThread(pool)) != RT_OK)
+    {
+      pthread_mutex_unlock(&pool->poolLock);
       return err;
+    }
     if(pool->threadCount == pool->maxThreadCount - 1)
       rtLog_Debug("%s reached max thread count %zu", __FUNCTION__, pool->maxThreadCount);
   }


### PR DESCRIPTION
The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @jweese and @eelenberg . This PR updates rtThreadPool to call `pthread_mutex_unlock` in early exit conditions where it was missing.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>