### PR TITLE
Add proper LOCK & missing UNLOCK at early exit for rbus_element

### DIFF
--- a/src/rbus/rbus_element.c
+++ b/src/rbus/rbus_element.c
@@ -392,17 +392,14 @@ elementNode* retrieveElement(elementNode* root, const char* elmentName)
     char* saveptr = NULL;
     elementNode* currentNode = root;
     elementNode* nextNode = NULL;
-    int tokenFound = 0;
-
-    LOCK();
+    int tokenFound = 0;  
     RBUSLOG_DEBUG("Request to retrieve element [%s]", elmentName);
     if(currentNode == NULL)
     {
         return NULL;
     }
-
+    LOCK();
     name = strdup(elmentName);
-
     nextNode = currentNode->child;
 
     /*TODO if name is a table row with an alias containing a dot, this will break (e.g. "Foo.[alias.1]")*/
@@ -496,14 +493,13 @@ elementNode* retrieveInstanceElementEx(rbusHandle_t handle, elementNode* root, c
     bool isWildcard = false;
 
     RBUSLOG_DEBUG("Request to retrieve element [%s]", elmentName);
-    LOCK();
+   
     if(currentNode == NULL)
     {
         return NULL;
     }
-
+    LOCK();	
     name = strdup(elmentName);
-
     nextNode = currentNode->child;
 
     /*TODO if name is a table row with an alias containing a dot, this will break (e.g. "Foo.[alias.1]")*/
@@ -1024,6 +1020,7 @@ elementNode* instantiateTableRow(elementNode* tableNode, uint32_t instNum, char 
 
     if(!rowTemplate)
     {
+	UNLOCK();
         assert(false);
         RBUSLOG_ERROR("ERROR: row template not found for table %s", tableNode->fullName);
         return NULL;


### PR DESCRIPTION
Reason for change: Added proper locking and the missing unlock at early exit conditions where it was previously missing.
Signed-off-by: Netaji Panigrahi [Netaji_Panigrahi@comcast.com](mailto:Netaji_Panigrahi@comcast.com)