### PR TITLE
RDKB-57891: Rollback support of DM parameters handled in RBUS

### DIFF
--- a/include/rbus_property.h
+++ b/include/rbus_property.h
@@ -310,7 +310,7 @@ void rbusProperty_Append(rbusProperty_t property, rbusProperty_t back);
 uint32_t rbusProperty_Count(rbusProperty_t property);
 
 void rbusProperty_fwrite(rbusProperty_t prop, int depth, FILE* fout);
-
+void rbusProperty_Copy(rbusProperty_t destination, rbusProperty_t source);
 #ifdef __cplusplus
 }
 #endif

--- a/src/rbus/rbus_property.c
+++ b/src/rbus/rbus_property.c
@@ -297,6 +297,23 @@ rbusProperty_t rbusProperty_AppendBytes(rbusProperty_t property, char const* nam
     return p;
 }
 
+
+void rbusProperty_Copy(rbusProperty_t destination, rbusProperty_t source)
+{
+    if(destination->name)
+    {
+        free(destination->name);
+        destination->name = NULL;
+    }
+    if(source->name)
+        destination->name = strdup(source->name);
+    rbusValue_Copy(destination->value, source->value);
+    if(source->next)
+    {
+        rbusProperty_SetNext(destination, source->next);
+    }
+}
+
 #define DEFINE_PROPERTY_TYPE_FUNCS(T1, T2, T3, T4)\
 rbusProperty_t rbusProperty_Init##T1(char const* name, T2 data)\
 {\


### PR DESCRIPTION
Reason for change: Rollback all DML values to its initial value when there is a failure in setting multiple DMLs
Test Procedure: Tested & Verified
Risks: Medium
Priority: P1