### PR TITLE
RDKB-57964: Delay in getting the ipv6 after WanManager Restart

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2588,7 +2588,7 @@ static void _subscribe_callback_handler (rbusHandle_t handle, rbusMessage reques
                     event.data = data;
                     rbusMessage_SetInt32(*response, 1); /* Based on this value initial value will be published to the consumer in
                                                            rbusEvent_SubscribeWithRetries() function call */
-                    rbusEventData_appendToMessage(&event, filter, interval, duration, handleInfo->componentId, *response);
+                    rbusEventData_appendToMessage(&event, filter, interval, duration, componentId, *response);
                     rbusProperty_Release(tmpProperties);
                 }
                 rbusObject_Release(data);

--- a/test/rbus/CMakeLists.txt
+++ b/test/rbus/CMakeLists.txt
@@ -68,6 +68,17 @@ add_executable(multiConsumerThreadsForSingleEvent
 add_dependencies(multiConsumerThreadsForSingleEvent rbus)
 target_link_libraries(multiConsumerThreadsForSingleEvent rbus)
 
+#Subscribe with Initial Value when there is multiple rbus_open
+add_executable(multiRbusOpenEventProvider
+    multiRbusOpenEventProvider/multiRbusOpenEventProvider.c)
+add_dependencies(multiRbusOpenEventProvider rbus)
+target_link_libraries(multiRbusOpenEventProvider rbus)
+
+add_executable(multiRbusOpenEventConsumer
+	multiRbusOpenEventConsumer/multiRbusOpenEventConsumer.c)
+add_dependencies(multiRbusOpenEventConsumer rbus)
+target_link_libraries(multiRbusOpenEventConsumer rbus)
+
 add_executable(rbusTestConsumer 
     consumer/rbusTestConsumer.c
     consumer/elementTree.c

--- a/test/rbus/multiRbusOpenEventConsumer/multiRbusOpenEventConsumer.c
+++ b/test/rbus/multiRbusOpenEventConsumer/multiRbusOpenEventConsumer.c
@@ -1,0 +1,153 @@
+
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2016 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <string.h>
+#include <rbus.h>
+int runtime = 60;
+
+static void eventReceiveHandler(
+    rbusHandle_t handle,
+    rbusEvent_t const* event,
+    rbusEventSubscription_t* subscription)
+{
+    (void) handle;
+    rbusValue_t value = rbusObject_GetValue(event->data, "value");
+
+    printf("Consumer receiver 1st general event %s\n", event->name);
+
+    if(value)
+        printf("  Value: %s\n", rbusValue_GetString(value, NULL));
+
+    printf("  My user data: %s\n", (char*)subscription->userData);
+}
+
+int main(int argc, char *argv[])
+{
+    int rc1 = RBUS_ERROR_SUCCESS;
+    int rc2 = RBUS_ERROR_SUCCESS;
+    const char* component1 = "multiRbusOpenEventConsumer";
+    const char* component2 = "EventConsumer";
+    rbusHandle_t handle1;
+    rbusHandle_t handle2;
+    rbusEventSubscription_t subscription = {"Device.Sample.InitialEvent1!", NULL, 0, 0, eventReceiveHandler, NULL, NULL, NULL, true};
+
+    rc1 = rbus_open(&handle1, component1);
+    if(rc1 != RBUS_ERROR_SUCCESS)
+    {
+        printf("consumer: rbus_open handle1 failed: %d\n", rc1);
+        goto exit1;
+    }
+
+    rc2 = rbus_open(&handle2, component2);
+    if(rc2 != RBUS_ERROR_SUCCESS)
+    {
+        printf("consumer: rbus_open handle2 failed: %d\n", rc2);
+        goto exit2;
+    }
+    if(argc == 2 && (strcmp(argv[1],"1")==0))
+    {
+        rc2 = rbusEvent_SubscribeEx(
+            handle2,
+            &subscription,
+            1,
+            60);
+	if(rc2 != RBUS_ERROR_SUCCESS)
+	{
+		printf("consumer: rbusEvent_Subscribe handle2 failed with err:%d\n", rc2);
+	}
+	else
+		printf("consumer: Subscribed to Device.Provider.Event1! with handle2, component:%s\n", component2);
+
+	sleep(1);
+	goto exit;
+    }
+    if((argc == 2 && (strcmp(argv[1],"2")==0)) || argc == 1)
+    {
+	printf("handle1 and handle2 Subscribing to Device.Provider1.Event1!\n");
+	rc1 = rbusEvent_SubscribeEx(
+            handle1,
+            &subscription,
+            1,
+            60);
+	if(rc1 != RBUS_ERROR_SUCCESS)
+	{
+            printf("consumer: rbusEvent_Subscribe handle1 failed with err:%d\n", rc1);
+	}
+	else
+            printf("consumer: Subscribed to Device.Provider.Event1! with handle1, component:%s\n", component1);
+	sleep(1);
+	rc2 = rbusEvent_SubscribeEx(
+            handle2,
+            &subscription,
+            1,
+            60);
+	if(rc2 != RBUS_ERROR_SUCCESS)
+	{
+            printf("consumer: rbusEvent_Subscribe handle2 failed with err:%d\n", rc2);
+	}
+	else
+            printf("consumer: Subscribed to Device.Provider.Event1! with handle2, component:%s\n", component2);
+
+	sleep(1);
+    }
+
+    rc1 = rbusEvent_UnsubscribeEx(
+            handle1,
+	    &subscription,
+            1);
+    if(rc1 != RBUS_ERROR_SUCCESS)
+    {
+        printf("Unsubscribing handle1 err:%d\n", rc1);
+    }
+    else
+        printf("consumer: UnSubscribed to Device.Provider.Event1! with handle1\n");
+ 
+exit:
+    rc2 = rbusEvent_UnsubscribeEx(
+            handle2,
+            &subscription,
+	    1);
+    if(rc2 != RBUS_ERROR_SUCCESS)
+    {
+        printf("Unsubscribing handle2 failed :%d\n", rc2);
+    }
+    else
+        printf("consumer: UnSubscribed to Device.Provider.Event1! with handle2\n");
+
+    rc2 = rbus_close(handle2);
+    if(rc2 != RBUS_ERROR_SUCCESS)
+    {
+        printf("consumer: rbus_close handle2 err: %d\n", rc2);
+    }
+
+exit2:
+    rc1 = rbus_close(handle1);
+    if(rc1 != RBUS_ERROR_SUCCESS)
+    {
+        printf("consumer: rbus_close handle1 failed: %d\n", rc1);
+    }
+exit1:
+    return rc2;
+}
+

--- a/test/rbus/multiRbusOpenEventConsumer/multiRbusOpenEventConsumer.c
+++ b/test/rbus/multiRbusOpenEventConsumer/multiRbusOpenEventConsumer.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 		printf("consumer: rbusEvent_Subscribe handle2 failed with err:%d\n", rc2);
 	}
 	else
-		printf("consumer: Subscribed to Device.Provider.Event1! with handle2, component:%s\n", component2);
+		printf("consumer: Subscribed to Device.Sample.InitialEvent1! with handle2, component:%s\n", component2);
 
 	sleep(1);
 	goto exit;
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
             printf("consumer: rbusEvent_Subscribe handle1 failed with err:%d\n", rc1);
 	}
 	else
-            printf("consumer: Subscribed to Device.Provider.Event1! with handle1, component:%s\n", component1);
+            printf("consumer: Subscribed to Device.Sample.InitialEvent1! with handle1, component:%s\n", component1);
 	sleep(1);
 	rc2 = rbusEvent_SubscribeEx(
             handle2,
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
             printf("consumer: rbusEvent_Subscribe handle2 failed with err:%d\n", rc2);
 	}
 	else
-            printf("consumer: Subscribed to Device.Provider.Event1! with handle2, component:%s\n", component2);
+            printf("consumer: Subscribed to Device.Sample.InitialEvent1! with handle2, component:%s\n", component2);
 
 	sleep(1);
     }
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
         printf("Unsubscribing handle1 err:%d\n", rc1);
     }
     else
-        printf("consumer: UnSubscribed to Device.Provider.Event1! with handle1\n");
+        printf("consumer: UnSubscribed to Device.Sample.InitialEvent1! with handle1\n");
  
 exit:
     rc2 = rbusEvent_UnsubscribeEx(
@@ -133,7 +133,7 @@ exit:
         printf("Unsubscribing handle2 failed :%d\n", rc2);
     }
     else
-        printf("consumer: UnSubscribed to Device.Provider.Event1! with handle2\n");
+        printf("consumer: UnSubscribed to Device.Sample.InitialEvent1! with handle2\n");
 
     rc2 = rbus_close(handle2);
     if(rc2 != RBUS_ERROR_SUCCESS)

--- a/test/rbus/multiRbusOpenEventProvider/multiRbusOpenEventProvider.c
+++ b/test/rbus/multiRbusOpenEventProvider/multiRbusOpenEventProvider.c
@@ -1,0 +1,114 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file
+ * the following copyright and licenses apply:
+ *
+ * Copyright 2016 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include<unistd.h>
+#include <rbus.h>
+
+
+int loopFor = 40;
+int subscribed1 = 0;
+
+rbusError_t getHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options)
+{
+    char const* name = rbusProperty_GetName(property);
+    (void)handle;
+    (void)options;
+
+    if(strcmp(name, "Device.Sample.InitialEvent1!") == 0)
+    {
+	char buff[24];
+	rbusValue_t value;
+	snprintf(buff, sizeof(buff), "%s\n",options->requestingComponent);
+	rbusValue_Init(&value);
+	rbusValue_SetString(value, buff);
+	rbusProperty_SetValue(property, value);
+	rbusProperty_fwrite(property, 0, stdout);
+	rbusValue_Release(value);
+    }
+    return RBUS_ERROR_SUCCESS;
+}
+
+rbusError_t eventSubHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char* eventName, rbusFilter_t filter, int32_t interval, bool* autoPublish)
+{
+    (void)handle;
+    (void)filter;
+    (void)autoPublish;
+    (void)interval;
+
+    printf(
+        "eventSubHandler called:\n" \
+        "\taction=%s\n" \
+        "\teventName=%s\n",
+        action == RBUS_EVENT_ACTION_SUBSCRIBE ? "subscribe" : "unsubscribe",
+        eventName);
+
+    if(strcmp("Device.Sample.InitialEvent1!", eventName))
+    {
+        printf("provider: eventSubHandler unexpected eventName %s\n", eventName);
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+int main(int argc, char *argv[])
+{
+    (void)(argc);
+    (void)(argv);
+
+    rbusHandle_t handle;
+    int rc = RBUS_ERROR_SUCCESS;
+
+    char componentName[] = "EventProvider";
+
+    rbusDataElement_t dataElements[] = {
+        {"Device.Sample.InitialEvent1!", RBUS_ELEMENT_TYPE_EVENT, {getHandler, NULL, NULL, NULL, eventSubHandler, NULL}},
+    };
+
+    printf("provider: start\n");
+
+    rc = rbus_open(&handle, componentName);
+    if(rc != RBUS_ERROR_SUCCESS)
+    {
+        printf("provider: rbus_open failed: %d\n", rc);
+        goto exit2;
+    }
+
+    rc = rbus_regDataElements(handle, 1, dataElements);
+    if(rc != RBUS_ERROR_SUCCESS)
+    {
+        printf("provider: rbus_regDataElements failed: %d\n", rc);
+        goto exit1;
+    }
+    while (loopFor != 0)
+    {
+        printf("provider: exiting in %d seconds\n", loopFor);
+        loopFor--;
+	sleep(1);
+    }
+
+    rbus_unregDataElements(handle, 1, dataElements);
+exit1:
+    rbus_close(handle);
+exit2:
+    printf("provider: exit\n");
+    return rc;
+}

--- a/test/rbus/multiRbusOpenEventProvider/multiRbusOpenEventProvider.c
+++ b/test/rbus/multiRbusOpenEventProvider/multiRbusOpenEventProvider.c
@@ -23,9 +23,7 @@
 #include<unistd.h>
 #include <rbus.h>
 
-
 int loopFor = 40;
-int subscribed1 = 0;
 
 rbusError_t getHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options)
 {
@@ -35,9 +33,9 @@ rbusError_t getHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHand
 
     if(strcmp(name, "Device.Sample.InitialEvent1!") == 0)
     {
-	char buff[24];
+	char buff[128];
 	rbusValue_t value;
-	snprintf(buff, sizeof(buff), "%s\n",options->requestingComponent);
+	snprintf(buff, sizeof(buff), "%s",options->requestingComponent);
 	rbusValue_Init(&value);
 	rbusValue_SetString(value, buff);
 	rbusProperty_SetValue(property, value);


### PR DESCRIPTION
Reason for change: The subscriberID sent while publishing the initial value is invalid and that leads the subscriber side of the middleware to ignore the received message itself and causes no event received at the consumer/subscriber
Test Procedure: As per RDKB-57964
Risks: Low