### PR TITLE
RDKB-59706 : fix memory leak in _setMultiInternal

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4302,7 +4302,10 @@ rbusError_t _setMultiInternal(rbusHandle_t handle, uint32_t numProps, rbusProper
                                 if(result == RBUS_ERROR_SUCCESS)
                                     RBUSLOG_DEBUG("Successfully reverted back the values");
                                 else if((result != RBUS_ERROR_SUCCESS) && (pTempFailedElement))
+				{
                                     RBUSLOG_WARN("Failed to rollback %s\n",pTempFailedElement);
+				    free(pTempFailedElement);
+				}
                             }
                             if(legacyRetCode > RBUS_LEGACY_ERR_SUCCESS)
                             {


### PR DESCRIPTION
Reason for change: Fix Memory leak in _setMultiInternal function.
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com