### PR TITLE
RDKB-59722 : memory leak in rbus_getExt

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3616,7 +3616,13 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
         if (!_is_wildcard_query(pParamNames[0]))
         {
             rbusProperty_t outputVals = NULL;
-            rbusValue_t getVal;
+            rbusValue_t getVal = NULL;
+
+            /* Initialize */
+            *retProperties = NULL;
+            *numValues = 0;
+
+            /*Do get the single param */
             errorcode = rbus_get(handle, pParamNames[0], &getVal);
             if(RBUS_ERROR_SUCCESS == errorcode)
             {


### PR DESCRIPTION
Reason for change: When rbus_get is called for a single parameter without a wildcard query in rbus_getExt does not return a success or failure status as expected. 
Test Procedure: Run valgrind
Risks: Medium