### PR TITLE
Fix memory leak in _setMultiInternal function

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -4192,6 +4192,7 @@ rbusError_t _setMultiInternal(rbusHandle_t handle, uint32_t numProps, rbusProper
             if(errorcode == RBUS_ERROR_INVALID_INPUT)
             {
                 free(componentNames);
+	        free(pParamNames);
                 return RBUS_ERROR_INVALID_INPUT;
             }
 


### PR DESCRIPTION
Reason for change : memory leak in setmultiInternal  when rbus_discoverComponentName returns invalid_input.
