### PR TITLE
rtmessage: repair NULL Pointer Dereference for rtConnection

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -290,13 +290,15 @@ rtConnection_ConnectAndRegister(rtConnection con, rtTime_t* reconnect_time)
   int first_to_handle = false;
   int is_first_connect = true;
   int reconnect_in_progress = 0;
-  rtTime_t last_reconnect_time = con->reconnect_time;
+  rtTime_t last_reconnect_time;
   char tbuff1[100];
   char tbuff2[100];
   char tbuff3[100];
 
   if (!con)
     return rtErrorFromErrno(EINVAL);
+
+  last_reconnect_time = con->reconnect_time;
 
   if(con->fd != -1)
     is_first_connect = false;


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI coder and reviewed by @jweese and @fwph. `con` is dereferenced in order to set `last_reconnect_time`, but this happens before `con` is checked to be non-null. This change moves the assignment below the check.

Compare to https://github.com/rdkcentral/rbus/pull/252/ -- a similar issue in `rbus_value.c` was fixed by moving the dereference below the check.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>