### PR TITLE
rtmessage: fixup integer underflow for rtrouted

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1502,13 +1502,15 @@ static char*
 rtRouted_GetClientName(rtConnectedClient* clnt)
 {
   size_t i;
-  i = rtVector_Size(gRoutes);
+  size_t routes_size = rtVector_Size(gRoutes);
+
   char *clnt_name = NULL;
-  while(i--)
+
+  for (i = routes_size; i > 0; i--)
   {
-    rtRouteEntry* route = (rtRouteEntry *) rtVector_At(gRoutes, i);
+    rtRouteEntry* route = (rtRouteEntry *) rtVector_At(gRoutes, i - 1);
     if(route && (route->subscription) && (route->subscription->client)) {
-      if(strcmp( route->subscription->client->ident, clnt->ident ) == 0) {
+      if(strcmp(route->subscription->client->ident, clnt->ident ) == 0) {
         clnt_name = route->expression;
         break;
       }


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph.

After the final iteration of this loop, `i` is zero and the loop terminates, and then `i` is decremented and underflows. In practice, this is not a problem since `i` is never used again, but it may be flagged by a static analyzer. This changes to a for loop that doesn't underflow.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>