### PR TITLE
rtmessage: check return value of setsockopt

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -323,11 +323,11 @@ rtConnection_ConnectAndRegister(rtConnection con, rtTime_t* reconnect_time)
         rtTime_Now(&con->reconnect_time);
       }
     }
-    pthread_mutex_unlock(&con->reconnect_mutex);  
+    pthread_mutex_unlock(&con->reconnect_mutex);
 
-    rtLog_Debug("ConnectAndRegister reconnect state first_to_handle=%d reconnect_in_progress=%d threads_time=[%s] last_reconnect_time=[%s] new_reconnect_time=[%s]", 
-      first_to_handle, reconnect_in_progress, 
-      rtTime_ToString(&con->start_time, tbuff1), 
+    rtLog_Debug("ConnectAndRegister reconnect state first_to_handle=%d reconnect_in_progress=%d threads_time=[%s] last_reconnect_time=[%s] new_reconnect_time=[%s]",
+      first_to_handle, reconnect_in_progress,
+      rtTime_ToString(&con->start_time, tbuff1),
       rtTime_ToString(&last_reconnect_time, tbuff2),
       rtTime_ToString(&con->reconnect_time, tbuff3));
 
@@ -367,7 +367,8 @@ rtConnection_ConnectAndRegister(rtConnection con, rtTime_t* reconnect_time)
   if (fdManip < 0)
     return rtErrorFromErrno(errno);
 
-  setsockopt(con->fd, SOL_TCP, TCP_NODELAY, &i, sizeof(i));
+  if (setsockopt(con->fd, SOL_TCP, TCP_NODELAY, &i, sizeof(i)) < 0)
+    rtLog_Debug("Error setting TCP_NODELAY: %s", strerror(errno));
 
   rtSocketStorage_ToString(&con->remote_endpoint, remote_addr, sizeof(remote_addr), &remote_port);
 


### PR DESCRIPTION
The code changes in the PR were generated automatically by the Permanence AI Coder and reviewed by @jweese and @fwph. On line 368, `setsockopt` can fail, so this change checks its return value. Since the original code does not return early on failure, neither does this change, but it does log the error. Some minor trailing whitespace was also removed.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>