### PR TITLE
core: check return value of remove

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2503,7 +2503,9 @@ static void _rbuscore_directconnection_save_to_cache()
     if(0 == sz)
     {
         RBUSCORELOG_DEBUG("no direct connection exist, so removing cache file");
-        remove(cacheFileName);
+        if (remove(cacheFileName) != 0) {
+            RBUSCORELOG_ERROR("failed to remove %s", cacheFileName);
+        }
     }
     else
     {


### PR DESCRIPTION
The changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @jweese and @fwph. This change checks the return value of the `remove` call, and adds a log message on error.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>