### PR TITLE
rtmessage: check return value for mkdir

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1767,7 +1767,7 @@ int main(int argc, char* argv[])
     printf("failed to open pid file. %s\n", strerror(errno));
     return 0;
   }
-  
+
   int fd = fileno(pid_file);
   int retval = flock(fd, LOCK_EX | LOCK_NB);
   if (retval != 0 && errno == EWOULDBLOCK)
@@ -1775,7 +1775,9 @@ int main(int argc, char* argv[])
     rtLog_Warn("another instance of rtrouted is already running");
     exit(12);
   }
-  mkdir("/tmp/.rbus", 0755);
+  if (mkdir("/tmp/.rbus", 0755) == -1) {
+    rtLog_Warn("Failed to create directory /tmp/.rbus. %s", strerror(errno));
+  }
 #ifdef ENABLE_RDKLOGGER
     rdk_logger_init("/etc/debug.ini");
 #endif
@@ -1807,7 +1809,7 @@ int main(int argc, char* argv[])
   while (1)
   {
     int option_index = 0;
-    static struct option long_options[] = 
+    static struct option long_options[] =
     {
       {"foreground",  no_argument,        0, 'f'},
       {"no-delay",    no_argument,        0, 'd' },


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. This change checks the return value of the `mkdir` call, and adds a log message on failure. Some minor trailing whitespace was also removed.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>