### PR TITLE
rbus: fix TokenChain leak in rbus_subscriptions

### DIFF
--- a/src/rbus/rbus_subscriptions.c
+++ b/src/rbus/rbus_subscriptions.c
@@ -136,7 +136,10 @@ rbusSubscription_t* rbusSubscriptions_addSubscription(rbusSubscriptions_t subscr
         return NULL;
     }
     if(!subscriptions)
+    {
+        TokenChain_destroy(tokens);
         return NULL;
+    }
 
     sub = rt_malloc(sizeof(rbusSubscription_t));
 


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. In the case of an early return where `subscriptions` is NULL, the current code leaks the newly-allocated token chain in `tokens`. It was meant to be assigned into `sub->tokens` later. Instead, on this early return, this change destroys the unused token chain.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>