### PR TITLE
core: fix unused variable assignment

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -3077,7 +3077,6 @@ rbusCoreError_t rbuscore_closePrivateConnection(const char *pParameterName)
                 memcpy(providerName, obj->m_providerName, MAX_OBJECT_NAME_LENGTH);
                 providerName[MAX_OBJECT_NAME_LENGTH] = '\0';
                 rtVector_RemoveItem(gListOfClientDirectDMLs, obj, rtVector_Cleanup_Free);
-                obj = NULL;
             }
             rbusMessage_Release(response);
         }


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. The assignment to `obj` here is immediately and unconditionally overwritten by the result of the call to `rtVector_Find` just below.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>