### PR TITLE
RDKB-59999 : Drop Incoming Request when Provider is NOT Responding

### DIFF
--- a/sampleapps/consumer/rbusDmlBlockingConsumer.c
+++ b/sampleapps/consumer/rbusDmlBlockingConsumer.c
@@ -52,20 +52,21 @@ int main(int argc, char *argv[])
     rc = rbus_open(&handle, "rbusSubConsumer");
     if(rc != RBUS_ERROR_SUCCESS)
     {
-	printf("consumer: rbus_open failed: %d\n", rc);
-	goto exit1;
+       printf("consumer: rbus_open failed: %d\n", rc);
+       goto exit1;
     }
     rbus_setLogLevel(RBUS_LOG_DEBUG);
+    rbusHandle_ConfigGetTimeout(handle, 2000);
+
     rbusValue_t value = NULL;
     int count =0;
     while(1)
     {
-        rc = rbus_get(handle, paramNames[count], &value);
-        sleep(0.1);
         if(count >= TotalParams)
             count = 0;
-        else
-            count++;
+        rc = rbus_get(handle, paramNames[count], &value);
+        sleep(0.1);
+        count++;
     }
 
     rbus_close(handle);

--- a/sampleapps/provider/rbusBlockingProvider.c
+++ b/sampleapps/provider/rbusBlockingProvider.c
@@ -103,7 +103,8 @@ int main(int argc, char *argv[])
         goto exit2;
     }
 
-    rbus_setLogLevel(RBUS_LOG_DEBUG);
+    //rbus_setLogLevel(RBUS_LOG_DEBUG);
+    rbusHandle_ConfigGetTimeout(handle, 2000);
 
     rc = rbus_regDataElements(handle, dataElementsCount, dataElements);
     if(rc != RBUS_ERROR_SUCCESS)


### PR DESCRIPTION
Reason for change: Drop Incoming Request when Provider is NOT Responding/Blocked. When the request posted to the connection/callback_thread but if Provider is NOT consuming, the messages are queued up and eventually it leads to out-of-memory for the whole system. So It is decided to DROP all the incoming messages when the Queue size is 25.
Test Procedure: Added Test Programs to simulate
Priority: P0
Risks: High

Signed-off-by: dshett549 <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>