### PR TITLE
rbus_value: fix potential leak in rbusValue_Decode

### DIFF
--- a/src/rbus/rbus_value.c
+++ b/src/rbus/rbus_value.c
@@ -694,15 +694,18 @@ int rbusValue_Decode(rbusValue_t* value, rbusBuffer_t const buff)
     uint16_t    length;
     rbusValue_t current;
 
-    rbusValue_Init(value);
-
     if(!value)
         return -1;
+
+    rbusValue_Init(value);
+
     current = *value;
 
     // read value
-    rbusBuffer_ReadUInt16(buff, &type);
-    rbusBuffer_ReadUInt16(buff, &length);
+    if(rbusBuffer_ReadUInt16(buff, &type) != 0)
+        return -1;
+    if(rbusBuffer_ReadUInt16(buff, &length) != 0)
+        return -1;
     if(!buff)
         return -1;
     current->type = type;


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. If `rbusValue_Decode` is passed a null pointer for the value to initialize, it returns early immediately after calling `rbusValue_Init`. But `rbusValue_Init` unconditionally allocates memory (L121). The pointer to the allocation is both returned from `Init` and stored in the output pointer if it is non-null. Since `Init`'s return value is never stored at the callsite, calling it with a null value would leak that memory. This change moves the null check before the call to `Init`, so the early return will not leak.

This change also adds some checks on the return values of calls to `rbusBuffer_ReadUInt16`.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>