### PR TITLE
RDKB-60344: Remove extra newline added for rbus logs in device

### DIFF
--- a/src/core/rbuscore_logger.h
+++ b/src/core/rbuscore_logger.h
@@ -22,10 +22,10 @@
 #include <stdarg.h>
 #include "rtLog.h"
 
-#define RBUSCORELOG_ERROR(format, ...)       rtLog_ErrorPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_WARN(format, ...)        rtLog_WarnPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_INFO(format, ...)        rtLog_InfoPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_DEBUG(format, ...)       rtLog_DebugPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
-#define RBUSCORELOG_TRACE(format, ...)       rtLog_DebugPrint("RBUSCORE", format"\n", ##__VA_ARGS__)
+#define RBUSCORELOG_ERROR(format, ...)       rtLog_ErrorPrint("RBUSCORE", format, ##__VA_ARGS__)
+#define RBUSCORELOG_WARN(format, ...)        rtLog_WarnPrint("RBUSCORE", format, ##__VA_ARGS__)
+#define RBUSCORELOG_INFO(format, ...)        rtLog_InfoPrint("RBUSCORE", format, ##__VA_ARGS__)
+#define RBUSCORELOG_DEBUG(format, ...)       rtLog_DebugPrint("RBUSCORE", format, ##__VA_ARGS__)
+#define RBUSCORELOG_TRACE(format, ...)       rtLog_DebugPrint("RBUSCORE", format, ##__VA_ARGS__)
 
 #endif  // __RBUS_CORE_LOG_H__

--- a/src/rbus/rbus_log.h
+++ b/src/rbus/rbus_log.h
@@ -31,12 +31,12 @@
 #include <stdarg.h>
 #include "rtLog.h"
 
-#define RBUSLOG_TRACE(format, ...)       rtLog_DebugPrint("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_DEBUG(format, ...)       rtLog_DebugPrint("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_INFO(format, ...)        rtLog_InfoPrint("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_WARN(format, ...)        rtLog_WarnPrint("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_ERROR(format, ...)       rtLog_ErrorPrint("RBUS", format"\n", ##__VA_ARGS__)
-#define RBUSLOG_FATAL(format, ...)       rtLog_FatalPrint("RBUS", format"\n", ##__VA_ARGS__)
+#define RBUSLOG_TRACE(format, ...)       rtLog_DebugPrint("RBUS", format, ##__VA_ARGS__)
+#define RBUSLOG_DEBUG(format, ...)       rtLog_DebugPrint("RBUS", format, ##__VA_ARGS__)
+#define RBUSLOG_INFO(format, ...)        rtLog_InfoPrint("RBUS", format, ##__VA_ARGS__)
+#define RBUSLOG_WARN(format, ...)        rtLog_WarnPrint("RBUS", format, ##__VA_ARGS__)
+#define RBUSLOG_ERROR(format, ...)       rtLog_ErrorPrint("RBUS", format, ##__VA_ARGS__)
+#define RBUSLOG_FATAL(format, ...)       rtLog_FatalPrint("RBUS", format, ##__VA_ARGS__)
 
 #endif
 

--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -242,7 +242,7 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
     char module[MODULE_BUFFER_SIZE] = {0};
     rdk_LogLevel rdklevel = rdkLogLevelFromrtLogLevel(level);
     sprintf(module, "LOG.RDK.%s", mod);
-    RDK_LOG(rdklevel, module, buff);
+    RDK_LOG(rdklevel, module, "%s", buff);
   }
 #endif
   else
@@ -255,7 +255,7 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
     gettimeofday(&tv, NULL);
     lt = localtime(&tv.tv_sec);
 
-    printf("%.2d:%.2d:%.2d.%.6lld  %-10s %5s %s:%d -- Thread-%" RT_THREADID_FMT ": %s",
+    printf("%.2d:%.2d:%.2d.%.6lld  %-10s %5s %s:%d -- Thread-%" RT_THREADID_FMT ": %s\n",
         lt->tm_hour, lt->tm_min, lt->tm_sec, (long long int)tv.tv_usec, mod,
         rtLogLevelToString(level), path, line, threadId, buff);
   }

--- a/src/rtmessage/rtLog.h
+++ b/src/rtmessage/rtLog.h
@@ -86,11 +86,11 @@ void rtLogPrintf(rtLogLevel level, const char* pModule, const char* file, int li
 #define rtLog_ErrorPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_ERROR, mod, __FILE__, __LINE__, FORMAT)
 #define rtLog_FatalPrint(mod,FORMAT...)  rtLogPrintf(RT_LOG_FATAL, mod, __FILE__, __LINE__, FORMAT)
 
-#define rtLog_Debug(FORMAT,...) rtLog_DebugPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
-#define rtLog_Info(FORMAT,...)  rtLog_InfoPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
-#define rtLog_Warn(FORMAT,...)  rtLog_WarnPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
-#define rtLog_Error(FORMAT,...) rtLog_ErrorPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
-#define rtLog_Fatal(FORMAT,...) rtLog_FatalPrint("RTMESSAGE",FORMAT"\n", ##__VA_ARGS__)
+#define rtLog_Debug(FORMAT,...) rtLog_DebugPrint("RTMESSAGE",FORMAT, ##__VA_ARGS__)
+#define rtLog_Info(FORMAT,...)  rtLog_InfoPrint("RTMESSAGE",FORMAT, ##__VA_ARGS__)
+#define rtLog_Warn(FORMAT,...)  rtLog_WarnPrint("RTMESSAGE",FORMAT, ##__VA_ARGS__)
+#define rtLog_Error(FORMAT,...) rtLog_ErrorPrint("RTMESSAGE",FORMAT, ##__VA_ARGS__)
+#define rtLog_Fatal(FORMAT,...) rtLog_FatalPrint("RTMESSAGE",FORMAT, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Reason for change: To avoid extra newline in logfile
Test Procedure: Tested and verified
Priority: P1
Risks: Medium