### PR TITLE
rbus_object: fixup potential leak in InitMultiInstance

### DIFF
--- a/src/rbus/rbus_object.c
+++ b/src/rbus/rbus_object.c
@@ -56,6 +56,9 @@ rbusObject_t rbusObject_Init(rbusObject_t* pobject, char const* name)
 
 void rbusObject_InitMultiInstance(rbusObject_t* pobject, char const* name)
 {
+    if (pobject == NULL) {
+        return;
+    }
     rbusObject_Init(pobject, name);
     (*pobject)->type = RBUS_OBJECT_MULTI_INSTANCE;
 }


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. Here, `pobject` is passed directly to `rbusObject_Init` to hold its result but `pobject` is not modified inside that call. Therefore if it were null, the dereference `(*pobject)->type` would dereference a NULL pointer.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>