### PR TITLE
core: check return value of cache file removal

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2626,7 +2626,10 @@ invalidFile:
     if(pBuff)
         free(pBuff);
 
-    remove(cacheFileName);
+    if(remove(cacheFileName) != 0)
+    {
+        RBUSCORELOG_ERROR("failed to remove file %s", cacheFileName);
+    }
 }
 
 rbusServerDMLList_t* rbuscore_FindServerPrivateClient (const char *pParameterName, const char *pConsumerName)


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. The call to `remove` can fail, so this change checks its return value and logs an error message on failure. Compare to #273.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>