### PR TITLE
rbus_close: resolve potential race condition on eventSubs

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3158,10 +3158,10 @@ rbusError_t rbus_close(rbusHandle_t handle)
     snprintf(filename, RTMSG_HEADER_MAX_TOPIC_LENGTH-1, "%s%d_%d", "/tmp/.rbus/", getpid(), handleInfo->componentId);
     remove(filename);
 
+    HANDLE_EVENTSUBS_MUTEX_LOCK(handle);
     if(handleInfo->eventSubs)
     {
         int i;
-        HANDLE_EVENTSUBS_MUTEX_LOCK(handle);
         int count = (int)rtVector_Size(handleInfo->eventSubs);
         RBUSLOG_DEBUG("Cleaning up all (%d) subscriptions", count);
         for(i = 0; i < count; ++i)
@@ -3181,8 +3181,8 @@ rbusError_t rbus_close(rbusHandle_t handle)
         }
         rtVector_Destroy(handleInfo->eventSubs, NULL);
         handleInfo->eventSubs = NULL;
-        HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);
     }
+    HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);
 
     if (handleInfo->messageCallbacks)
     {


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. A race condition may exist since the code checks that `handle->eventSubs` is valid before it acquires the lock using its macro. Since the thread may wait to acquire a lock, a separate thread could have held the lock and called `rtVectorDestroy` between the time this thread checked it and the time this thread acquired the lock. This change moves the scope of the held lock outward slightly so that it covers both the checking of the vector and the later free and destruction operations.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>