### PR TITLE
core: fixup error code assignment in discoverWildcardDestinations

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1949,9 +1949,6 @@ rbusCoreError_t rbus_discoverWildcardDestinations(const char * expression, int *
             }
 
             rtMessage_Release(msg);
-
-            ret = RBUSCORE_SUCCESS;
-
         }
         else
         {


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. `ret` has an initial value of `RBUSCORE_SUCCESS` and is only reassigned in the memory allocation failures just above. In each case (either the `else` branch at L1944 or the `break` out of the loop ending at L1942), control flow immediately continues to this line overwriting `ret` with `RBUSCORE_SUCCESS` again, making those assignments useless. (In the case of no errors, the initial value of `RBUSCORE_SUCCESS` is correct anyway.) This change removes the unneeded assignment to correctly return the assigned error values.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>