### PR TITLE
rtmessage: add null check in rtMessage_Create

### DIFF
--- a/src/rtmessage/rtMessage.c
+++ b/src/rtmessage/rtMessage.c
@@ -45,17 +45,16 @@ struct _rtMessage
 rtError
 rtMessage_Create(rtMessage* message)
 {
+  if (!message)
+    return RT_FAIL;
   *message = (rtMessage) rt_try_malloc(sizeof(struct _rtMessage));
-  if(!*message)
+  if (!*message) {
     return rtErrorFromErrno(ENOMEM);
-  if (message)
-  {
-    (*message)->count = 0;
-    (*message)->json = cJSON_CreateObject();
-    rt_atomic_fetch_add(&(*message)->count, 1);
-    return RT_OK;
   }
-  return RT_FAIL;
+  (*message)->count = 0;
+  (*message)->json = cJSON_CreateObject();
+  rt_atomic_fetch_add(&(*message)->count, 1);
+  return RT_OK;
 }
 
 /**


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. The original code tries to assign some allocated memory to `*message` before checking to see if `message` is NULL. This change makes the logic closer to that of `rtMessage_Clone` below, but with an extra NULL check. `message` is first checked before it is assigned into, and then the result of the allocation is also checked. The rest of the function follows the example of `Clone` just below.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>