### PR TITLE
RDKEMW-5628: Implement setLogTypeFromEnvironment which reads RT_LOG_TYPE env variable

### DIFF
--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -110,6 +110,42 @@ struct LogLevelSetter
 static LogLevelSetter __logLevelSetter; // force RT_LOG_LEVEL to be read from env
 #endif
 
+#ifdef __cplusplus
+static void setLogTypeFromEnvironment()
+#else
+static void setLogTypeFromEnvironment() __attribute__((constructor));
+
+void setLogTypeFromEnvironment()
+#endif
+{
+  const char* s = getenv("RT_LOG_TYPE");
+  if (s && strlen(s))
+  {
+    rtLoggerSelection option;
+    if      (strcasecmp(s, "rtlogger") == 0) option = RT_USE_RTLOGGER;
+#ifdef ENABLE_RDKLOGGER
+    else if (strcasecmp(s, "rdklogger") == 0) option = RT_USE_RDKLOGGER;
+#endif
+    else
+    {
+      fprintf(stderr, "invalid RT_LOG_TYPE set: %s", s);
+      abort();
+    }
+    rtLog_SetOption(option);
+  }
+}
+
+#ifdef __cplusplus
+struct LogTypeSetter
+{
+  LogTypeSetter()
+  {
+    setLogTypeFromEnvironment();
+  }
+};
+
+static LogTypeSetter __logTypeSetter; // force RT_LOG_TYPE to be read from env
+#endif
 const char* rtLogLevelToString(rtLogLevel l)
 {
   const char* s = "OUT-OF-BOUNDS";


### PR DESCRIPTION
Reason for change: To have option to set log type
Test Procedure: Tested and verified
Priority: P1
Risks: Medium