### PR TITLE
rtmessage: fixup null termination in rtrouted L381

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -378,7 +378,8 @@ rtRouted_AddRoute(rtRouteMessageHandler handler, char const* exp, rtSubscription
   rtRouteEntry* route = (rtRouteEntry *) rt_malloc(sizeof(rtRouteEntry));
   route->subscription = subscription;
   route->message_handler = handler;
-  strncpy(route->expression, exp, RTMSG_MAX_EXPRESSION_LEN);
+  strncpy(route->expression, exp, RTMSG_MAX_EXPRESSION_LEN - 1);
+  route->expression[RTMSG_MAX_EXPRESSION_LEN - 1] = '\0';
   rtVector_PushBack(gRoutes, route);
   rtLog_Debug("AddRoute route=[%p] address=[%s] expression=[%s]", route, subscription->client->ident, exp);
   rtRoutingTree_AddTopicRoute(gRoutingTree, exp, (void *)route, 0/*ignfore duplicate entry*/);


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese. In the case that `strncpy` hits its limit, it may not null-terminate the destination string. This change explicitly adds a null character to the end of `route->expression`.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>