### PR TITLE
rtmessage: fixup null termination in rtrouted

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -733,7 +733,11 @@ static void prep_reply_header_from_request(rtMessageHeader *reply, const rtMessa
   reply->flags = rtMessageFlags_Response;
 
   strncpy(reply->topic, request->reply_topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  reply->topic[RTMSG_HEADER_MAX_TOPIC_LENGTH-1] = '\0';
+
   strncpy(reply->reply_topic, request->topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  reply->reply_topic[RTMSG_HEADER_MAX_TOPIC_LENGTH-1] = '\0';
+
   reply->topic_length = request->reply_topic_length;
   reply->reply_topic_length = request->topic_length;
 #ifdef MSG_ROUNDTRIP_TIME


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. Add explicit null termination for `topic` and `reply_topic` to handle the case where `strncpy` hits its limit.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>