### PR TITLE
rtmessage: fixup null termination in rtRouteBase L188,189

### DIFF
--- a/src/rtmessage/rtrouteBase.c
+++ b/src/rtmessage/rtrouteBase.c
@@ -186,7 +186,9 @@ _rtdirect_prepare_reply_from_request(rtMessageHeader *reply, const rtMessageHead
   reply->control_data = 0;//subscription->id;
 
   strncpy(reply->topic, request->reply_topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  reply->topic[RTMSG_HEADER_MAX_TOPIC_LENGTH-1] = '\0';
   strncpy(reply->reply_topic, request->topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  reply->reply_topic[RTMSG_HEADER_MAX_TOPIC_LENGTH-1] = '\0';
   reply->topic_length = request->reply_topic_length;
   reply->reply_topic_length = request->topic_length;
 }


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. Add explicit null termination for `reply` and `reply_topic` to handle the case where `strncpy` could hit its limit and fail to null-terminate.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>