### PR TITLE
rtmessage: fixup null termination in rtrouted L792

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -789,7 +789,8 @@ rtRouted_OnMessageSubscribe(rtConnectedClient* sender, rtMessageHeader* hdr, uin
 
           if(strstr(expression, ".INBOX.") && sender->inbox[0] == '\0')
           {
-              strncpy(sender->inbox, expression, RTMSG_HEADER_MAX_TOPIC_LENGTH);
+              strncpy(sender->inbox, expression, RTMSG_HEADER_MAX_TOPIC_LENGTH - 1);
+              sender->inbox[RTMSG_HEADER_MAX_TOPIC_LENGTH - 1] = '\0';
               rtLog_Debug("init client inbox to %s", sender->inbox);
               rtRouted_SendAdvisoryMessage(sender, rtAdviseClientConnect);
           }


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese, @fwph, @eelenberg, and @josephhackman. This adds explicit null termination to `sender->inbox` to handle the case where the `strncpy` call could have hit its limit.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>