### PR TITLE
rtmessage: fixup null termination in rtrouted L1474

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1471,7 +1471,8 @@ dispatch:
     if(clnt->header.flags & rtMessageFlags_Request)
     {
       /*Turn this message around without the payload. Set the right error flag.*/
-      strncpy(clnt->header.topic, clnt->header.reply_topic, (strlen(clnt->header.reply_topic) + 1));
+      strncpy(clnt->header.topic, clnt->header.reply_topic, sizeof(clnt->header.topic) - 1);
+      clnt->header.topic[sizeof(clnt->header.topic) - 1] = '\0';
       clnt->header.flags &= ~rtMessageFlags_Request; 
       clnt->header.flags |= (rtMessageFlags_Response | rtMessageFlags_Undeliverable);
       clnt->header.payload_length = 0;


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. This adds explicit null termination to `clnt->header.topic` to handle the case where the call to `strncpy` hits its limit. The length argument was also changed to use the actual destination buffer `header.topic` rather than depending on the length of the string in the source buffer `header.reply_topic`. Note that the use of `sizeof` for the length argument is safe since `header.topic` is an array, not a pointer.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>