### PR TITLE
core: fixup null termination in rbuscore L2993,2994

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2990,8 +2990,12 @@ rbusCoreError_t rbuscore_openPrivateConnectionToProvider(rtConnection *pPrivateC
             /* Update the Vector to avoid multiple connections */
             pNewObj = rt_malloc(sizeof(rbusClientDMLList_t));
 
-            strcpy(pNewObj->m_privateDML, pParameterName);
-            strcpy(pNewObj->m_providerName, pProviderName);
+            strncpy(pNewObj->m_privateDML, pParameterName, sizeof(pNewObj->m_privateDML) - 1);
+            pNewObj->m_privateDML[sizeof(pNewObj->m_privateDML) - 1] = '\0';
+
+            strncpy(pNewObj->m_providerName, pProviderName, sizeof(pNewObj->m_providerName) - 1);
+            pNewObj->m_providerName[sizeof(pNewObj->m_providerName) - 1] = '\0';
+
             pNewObj->m_privConn = connection;
 
             rtVector_PushBack(gListOfClientDirectDMLs, pNewObj);


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. This moves 2 calls from `strcpy` to `strncpy` and also takes care to null terminate in the case where `strncpy` could hit its limit. Note that the use of `sizeof` to calculate the max size of each buffer is valid here, since both `m_privateDML` and `m_providerName` are arrays of known size.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>