### PR TITLE
rtmessage: fixup null termination in rtRoutingTree

### DIFF
--- a/src/rtmessage/rtRoutingTree.c
+++ b/src/rtmessage/rtRoutingTree.c
@@ -63,8 +63,10 @@ static rtTreeTopic* createTreeTopic(const char* name, rtTreeTopic* parent)
     treeTopic->name = strdup(name);
     if(parent->fullName)
     {
-        treeTopic->fullName = rt_malloc(strlen(parent->fullName) + 1 + strlen(name) + 1);
-        sprintf(treeTopic->fullName, "%s.%s", parent->fullName, name);
+        size_t len1 = strlen(parent->fullName);
+        size_t len2 = strlen(name);
+        treeTopic->fullName = rt_malloc(len1 + 1 + len2 + 1);
+        snprintf(treeTopic->fullName, len1 + 1 + len2 + 1, "%s.%s", parent->fullName, name);
     }
     else
     {


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. This changes the `sprintf` call to a `snprintf` call, which will automatically null terminate the destination buffer should the input arguments overflow the calculated length.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>