### PR TITLE
core: fixup null termination for server_object_create

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -192,7 +192,8 @@ int server_object_compare(const void* left, const void* right)
 void server_object_create(server_object_t* obj, char const* name, rbus_callback_t callback, void* data)
 {
     (*obj) = rt_malloc(sizeof(struct _server_object));
-    strcpy((*obj)->name, name);
+    strncpy((*obj)->name, name, sizeof((*obj)->name) - 1);
+    (*obj)->name[sizeof((*obj)->name) - 1] = '\0';
     (*obj)->callback = callback;
     (*obj)->data = data;
     (*obj)->process_event_subscriptions = false;


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. This changes a `strcpy` call to `strncpy` and explicitly null terminates `(*obj)->name` to handle the case where `strncpy` may hit its limit. Note that `(*obj)->name` is an array of known size.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>