### PR TITLE
core: fixup null termination for client_event_create

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -286,7 +286,8 @@ void client_event_create(client_event_t* event, const char* name, rbus_event_cal
     (*event) = rt_malloc(sizeof(struct _client_event));
     (*event)->callback = callback;
     (*event)->data = data;
-    strcpy((*event)->name, name);
+    strncpy((*event)->name, name, sizeof((*event)->name) - 1);
+    (*event)->name[sizeof((*event)->name) - 1] = '\0';
 }
 
 int client_event_compare(const void* left, const void* right)


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. This changes a `strcpy` call to `strncpy` and explicitly null terminates `(*event)->name` to handle the case where `strncpy` may hit its limit. Note that `(*event)->name` is an array of known size.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>