### PR TITLE
core: fixup null termination for server_event_create

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -125,7 +125,8 @@ void server_event_create(server_event_t* event, const char * event_name, server_
 {
     (*event) = rt_malloc(sizeof(struct _server_event));
     rtVector_Create(&(*event)->listeners);
-    strcpy((*event)->name, event_name);
+    strncpy((*event)->name, event_name, sizeof((*event)->name) - 1);
+    (*event)->name[sizeof((*event)->name) - 1] = '\0';
     (*event)->object = obj;
     (*event)->sub_callback = sub_callback;
     (*event)->sub_data = sub_data;


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. This changes a `strcpy` call to `strncpy` and explicitly null terminates `(*event)->name` to handle the case where `strncpy` may hit its limit. Note that `(*event)->name` is an array of known size.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>