### PR TITLE
rtmessage: fixup potential leak in DiscoverObjectElements

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1058,6 +1058,10 @@ rtRouted_OnMessageDiscoverObjectElements(rtConnectedClient* sender, rtMessageHea
         rtLog_Info("%s() Response couldn't be sent.", __func__);
       rtMessage_Release(response);   
     }
+    else
+    {
+      rtMessage_Release(response);
+    }
   }
   else
     rtLog_Error("Cannot create response message to registered components.");

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1056,12 +1056,8 @@ rtRouted_OnMessageDiscoverObjectElements(rtConnectedClient* sender, rtMessageHea
       prep_reply_header_from_request(&new_header, hdr);
       if (RT_OK != rtRouted_SendMessage(&new_header, response, NULL))
         rtLog_Info("%s() Response couldn't be sent.", __func__);
-      rtMessage_Release(response);   
     }
-    else
-    {
-      rtMessage_Release(response);
-    }
+    rtMessage_Release(response);
   }
   else
     rtLog_Error("Cannot create response message to registered components.");


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @eelenberg. Near the top of this function, `response` is allocated via `rtMessage_Create`. When allocation succeeds, the next line immediately attempts to get `expression`. When `expression` is valid, `response` is freed via `rtMessage_Release` at the end of the large `if` block. However, in the case that `response` is created but `expression` is invalid, there is no `else` block and `rtMessage_Release` is never called. This change adds the appropriate `else` block.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>