### PR TITLE
RDKB-60555 : Move the subscription mutex after notify

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1126,13 +1126,18 @@ int subscribeHandlerImpl(
             RBUSLOG_ERROR("rbus interval subscription not supported for this event %s\n", eventName);
             return RBUS_ERROR_INVALID_OPERATION;
         }
+    }
 
-        subscription = rbusSubscriptions_getSubscription(handleInfo->subscriptions, listener, eventName, componentId, filter, interval, duration, rawData);
+    HANDLE_SUBS_MUTEX_LOCK(handle);
+    subscription = rbusSubscriptions_getSubscription(handleInfo->subscriptions, listener, eventName, componentId, filter, interval, duration, rawData);
+    if (added)
+    {
         if(!subscription)
         {
             subscription = rbusSubscriptions_addSubscription(handleInfo->subscriptions, listener, eventName, componentId, filter, interval, duration, autoPublish, el, rawData);
             if(!subscription)
             {
+                HANDLE_SUBS_MUTEX_UNLOCK(handle);
                 return RBUS_ERROR_INVALID_INPUT; // Adding fails because of invalid input
             }
             else
@@ -1140,16 +1145,16 @@ int subscribeHandlerImpl(
         }
         else
         {
+            HANDLE_SUBS_MUTEX_UNLOCK(handle);
             return RBUS_ERROR_SUBSCRIPTION_ALREADY_EXIST;
         }
     }
     else
     {
-        subscription = rbusSubscriptions_getSubscription(handleInfo->subscriptions, listener, eventName, componentId, filter, interval, duration, rawData);
-    
         if(!subscription)
         {
             RBUSLOG_ERROR("unsubscribing from event which isn't currectly subscribed to event=%s listener=%s", eventName, listener);
+            HANDLE_SUBS_MUTEX_UNLOCK(handle);
             return RBUS_ERROR_INVALID_INPUT; /*unsubscribing from event which isn't currectly subscribed to*/
         }
     }
@@ -1159,6 +1164,7 @@ int subscribeHandlerImpl(
     if(rawData && el->type != RBUS_ELEMENT_TYPE_EVENT)
     {
         RBUSLOG_INFO("rawDataSubscription is only allowed for events");
+        HANDLE_SUBS_MUTEX_UNLOCK(handle);
         return RBUS_ERROR_INVALID_INPUT;
     }
     else
@@ -1213,6 +1219,7 @@ int subscribeHandlerImpl(
     {
         rbusSubscriptions_removeSubscription(handleInfo->subscriptions, subscription);
     }
+    HANDLE_SUBS_MUTEX_UNLOCK(handle);
     return RBUS_ERROR_SUCCESS;
 }
 
@@ -2611,9 +2618,7 @@ static void _subscribe_callback_handler (rbusHandle_t handle, rbusMessage reques
             rbusMessage_GetInt32(request, &rawData);
             if(ret == RBUS_ERROR_SUCCESS)
             {
-                HANDLE_SUBS_MUTEX_LOCK(handle);
                 ret = subscribeHandlerImpl(handle, added, el, event_name, sender, componentId, interval, duration, filter, rawData, &subscriptionId);
-                HANDLE_SUBS_MUTEX_UNLOCK(handle);
             }
             rbusMessage_SetInt32(*response, ret);
 


### PR DESCRIPTION
Reason for change:
- The rbus library maintains list of active subscription that exist for any given DML.
- The rbus library uses mutex protection to access this list while adding, removing and while publishing.
- The flow in rbus library is, it locks the mutex when any consumer calls Subscribe/Unsubscribe and also informs the provider about the action if callback registered and adds to the list then unlocks the mutex.
- It is absolutely necessary to lock the mutex before we add/remove from the list but its not necessary to lock before notifying the provider about the action. Test Procedure: Verify Eventing
Risks: Medium