### PR TITLE
RDKB-60980 : Addressing issues in rtrouteBase.c

### DIFF
--- a/src/rtmessage/rtrouteBase.c
+++ b/src/rtmessage/rtrouteBase.c
@@ -507,9 +507,8 @@ rtRouteDirect_AcceptClientConnection(rtListener* listener)
 
   uint32_t one = 1;
   if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one)) < 0)
-  {
     rtLog_Warn("Failed to set TCP_NODELAY on accepted socket: %s", rtStrError(errno));
-  }
+
   return rtRouteDirect_RegisterNewClient(fd, &remote_endpoint);
 }
 

--- a/src/rtmessage/rtrouteBase.c
+++ b/src/rtmessage/rtrouteBase.c
@@ -588,10 +588,10 @@ rtRouteDirect_StartInstance(const char* socket_name, rtDriectClientHandler messa
   if (RT_OK != rtRouteBase_BindListener(socket_name, 1, 1, &myDirectListener))
   {
     if (strncmp(socket_name, "unix://", 7) == 0)
-    {	    
+    {
       if (remove(&socket_name[7]) != 0)
-	   rtLog_Warn("Failed to remove socket file %s", &socket_name[7]);
-    }   
+        rtLog_Warn("Failed to remove socket file %s", &socket_name[7]);
+    }
     return RT_FAIL;
   }
 
@@ -662,13 +662,13 @@ rtRouteDirect_StartInstance(const char* socket_name, rtDriectClientHandler messa
   free(route);
   if (myDirectListener)
   {
-      rtRouteBase_CloseListener(myDirectListener);
-      free(myDirectListener);
+    rtRouteBase_CloseListener(myDirectListener);
+    free(myDirectListener);
   }
   if (strncmp(socket_name, "unix://", 7) == 0)
   {
-       if (remove(&socket_name[7]) != 0)
-           rtLog_Warn("Failed to remove socket file %s", &socket_name[7]);
+    if (remove(&socket_name[7]) != 0)
+      rtLog_Warn("Failed to remove socket file %s", &socket_name[7]);
   }
   return RT_OK;
 }


### PR DESCRIPTION
Reason for change: Bug fix for Unchecked return value from library & dereference after null check in rtrouteBase.c file
Test Procedure: as per RDKB-60980
Risks: Medium