### PR TITLE
RDKB-60980 : Addressing the possible issues reported in rtrouted.c

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -213,7 +213,12 @@ rtRouted_ReadTextFile(char const* fname, char** content)
   pf = fopen(fname, "r");
   if (pf)
   {
-    fseek(pf, 0L, SEEK_END);
+    if (fseek(pf, 0L, SEEK_END) != 0) 
+    {
+      fclose(pf);
+      rtLog_Error("fseek failed for file %s. %s", fname, strerror(errno));
+      return RT_FAIL;
+    }
     sz = (size_t)ftell(pf);
     rewind(pf);
     *content = rt_malloc(sz+1);
@@ -221,11 +226,12 @@ rtRouted_ReadTextFile(char const* fname, char** content)
     {
       free(*content);
       *content = NULL;
-      rtLog_Error("failed to read file %s. %s", fname, strerror(errno));
-      err = RT_FAIL;
-    }
-    (*content)[sz] = 0;
-    fclose(pf);
+       rtLog_Error("failed to read file %s. %s", fname, strerror(errno));
+       err = RT_FAIL;
+     }
+     if (*content)
+      (*content)[sz] = 0;
+     fclose(pf);
   }
   else
   {
@@ -1696,7 +1702,10 @@ rtRouted_AcceptClientConnection(rtListener* listener)
   }
 
   uint32_t one = 1;
-  setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one));
+  if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one)) < 0) 
+  {
+    rtLog_Warn("setsockopt(TCP_NODELAY) failed on fd %d: %s", fd, strerror(errno));
+  }
 
   rtRouted_RegisterNewClient(fd, &remote_endpoint);
 }
@@ -1770,7 +1779,10 @@ int main(int argc, char* argv[])
     rtLog_Warn("another instance of rtrouted is already running");
     exit(12);
   }
-  mkdir("/tmp/.rbus", 0755);
+  if (mkdir("/tmp/.rbus", 0755) != 0 && errno != EEXIST)
+  {
+    rtLog_Warn("Failed to create /tmp/.rbus directory: %s", strerror(errno));
+  }
 #ifdef ENABLE_RDKLOGGER
     rdk_logger_init("/etc/debug.ini");
 #endif


### PR DESCRIPTION
Reason for change: Bug fix for unchecked return value from library and Argument cannot be negative in rtrouted.c
Test Procedure: as per RDKB-60980
Risks: Medium