### PR TITLE
RDKB-60980 : Addressing the possible issues reported in rtSemaphore.c

### DIFF
--- a/src/rtmessage/rtSemaphore.c
+++ b/src/rtmessage/rtSemaphore.c
@@ -86,7 +86,9 @@ rtError rtSemaphore_Post(rtSemaphore sem)
 rtError rtSemaphore_GetValue(rtSemaphore sem, int* val)
 {
   int rc = RT_OK;
+  ERROR_CHECK(pthread_mutex_lock(&sem->m));
   *val = sem->v;
+  ERROR_CHECK(pthread_mutex_unlock(&sem->m));
   return rc;
 }
 


### PR DESCRIPTION
Reason for change: Data race condition in rtSemaphore.c
Test Procedure: as per RDKB-60980
Risks: Medium