### PR TITLE
RDKB-60980 : Addressing issues in rtMessageHeader.c

### DIFF
--- a/src/rtmessage/rtMessageHeader.c
+++ b/src/rtmessage/rtMessageHeader.c
@@ -86,6 +86,9 @@ rtMessageHeader_Encode(rtMessageHeader* hdr, uint8_t* buff)
 rtError
 rtMessageHeader_Decode(rtMessageHeader* hdr, uint8_t const* buff)
 {
+  if (!hdr || !buff)
+    return RT_ERROR;
+
   uint8_t const* ptr = buff;
   uint16_t marker = 0;
   rtEncoder_DecodeUInt16(&ptr, &marker);
@@ -99,23 +102,23 @@ rtMessageHeader_Decode(rtMessageHeader* hdr, uint8_t const* buff)
   rtEncoder_DecodeUInt32(&ptr, &hdr->payload_length);
 
   rtEncoder_DecodeUInt32(&ptr, &hdr->topic_length);
-  if(hdr->topic_length >= sizeof(hdr->topic)) {
-    rtLog_Warn("RTROUTED_INVALID_LENGTH: rtMessageHeader_Decode() - topic_length %d", hdr->topic_length);
+  if(ptr == NULL) {
+    rtLog_Warn("RTROUTED_INVALID_PTR: rtMessageHeader_Decode() - PTR is NULL");
     return RT_ERROR;
   }
-  if(NULL == ptr) {
-    rtLog_Warn("RTROUTED_INVALID_PTR: rtMessageHeader_Decode() - PTR is NULL");
+  if(hdr->topic_length >= sizeof(hdr->topic)) {
+    rtLog_Warn("RTROUTED_INVALID_LENGTH: rtMessageHeader_Decode() - topic_length %d", hdr->topic_length);
     return RT_ERROR;
   }
   rtEncoder_DecodeStr(&ptr, hdr->topic, hdr->topic_length);
 
   rtEncoder_DecodeUInt32(&ptr, &hdr->reply_topic_length);
-  if(hdr->reply_topic_length >= sizeof(hdr->reply_topic)) {
-    rtLog_Warn("RTROUTED_INVALID_LENGTH: rtMessageHeader_Decode() - reply_topic_length %d", hdr->reply_topic_length);
+  if(ptr == NULL) {
+    rtLog_Warn("RTROUTED_INVALID_PTR: rtMessageHeader_Decode() - PTR is NULL");
     return RT_ERROR;
   }
-  if(NULL == ptr) {
-    rtLog_Warn("RTROUTED_INVALID_PTR: rtMessageHeader_Decode() - PTR is NULL");
+  if(hdr->reply_topic_length >= sizeof(hdr->reply_topic)) {
+    rtLog_Warn("RTROUTED_INVALID_LENGTH: rtMessageHeader_Decode() - reply_topic_length %d", hdr->reply_topic_length);
     return RT_ERROR;
   }
   rtEncoder_DecodeStr(&ptr, hdr->reply_topic, hdr->reply_topic_length);


### PR DESCRIPTION
Reason for change: Bug fix for Dereference before null check in rtMessageHeader_Decode function
Test Procedure: as per RDKB-60980
Risks: Medium