### PR TITLE
RDKB-60980 : Addressing the possible issues reported in rtConnecion.c

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -366,8 +366,10 @@ rtConnection_ConnectAndRegister(rtConnection con, rtTime_t* reconnect_time)
   if (fdManip < 0)
     return rtErrorFromErrno(errno);
 
-  setsockopt(con->fd, SOL_TCP, TCP_NODELAY, &i, sizeof(i));
-
+  if (setsockopt(con->fd, SOL_TCP, TCP_NODELAY, &i, sizeof(i)) < 0)
+  {
+    rtLog_Warn("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
+  }
   rtSocketStorage_ToString(&con->remote_endpoint, remote_addr, sizeof(remote_addr), &remote_port);
 
   int retry = 0;


### PR DESCRIPTION
Reason for change: Unchecked return value from library in rtConnection_ConnectAndRegister function
Test Procedure: as per RDKB-60980
Risks: Medium