### PR TITLE
RDK-58045 : Addressing the time of check bug

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2530,7 +2530,6 @@ static void _rbuscore_directconnection_save_to_cache()
 
 static void _rbuscore_directconnection_load_from_cache()
 {
-    struct stat st;
     long size;
     FILE* file = NULL;
     uint8_t* pBuff = NULL;
@@ -2539,12 +2538,6 @@ static void _rbuscore_directconnection_load_from_cache()
     snprintf(cacheFileName, 256, RBUS_DIRECT_FILE_CACHE, __progname);
 
     RBUSCORELOG_DEBUG("Entry of %s", __FUNCTION__);
-
-    if(stat(cacheFileName, &st) != 0)
-    {
-        RBUSCORELOG_DEBUG("file doesn't exist");
-        return;
-    }
 
     file = fopen(cacheFileName, "rb");
     if(!file)

--- a/src/rbus/rbus_handle.c
+++ b/src/rbus/rbus_handle.c
@@ -241,17 +241,14 @@ uint32_t rbusHandle_FetchGetTimeout(rbusHandle_t handle)
     char fileName[BUF_LEN] = {'\0'};
     snprintf(fileName, BUF_LEN-1, "%s/rbus_%s_timeout_get", RBUS_TMP_DIRECTORY, __progname);
     fileName[BUF_LEN-1] = '\0';
-    if (access(fileName, F_OK) == 0)
-    {
-        fp = fopen(fileName, "r");
-        if(fp != NULL) {
-            if (fgets(buf, sizeof(buf), fp) != NULL)
-                timeout = atoi(buf);
-            fclose(fp);
-        }
-        if (timeout > 0)
-            return timeout * 1000;
+    fp = fopen(fileName, "r");
+    if(fp != NULL) {
+        if (fgets(buf, sizeof(buf), fp) != NULL)
+            timeout = atoi(buf);
+    fclose(fp);
     }
+    if (timeout > 0)
+        return timeout * 1000;
     return handle->timeoutValues.getTimeout;
 }
 
@@ -264,17 +261,14 @@ uint32_t rbusHandle_FetchSetTimeout(rbusHandle_t handle)
     char fileName[BUF_LEN] = {'\0'};
     snprintf(fileName, BUF_LEN-1, "%s/rbus_%s_timeout_set", RBUS_TMP_DIRECTORY, __progname);
     fileName[BUF_LEN-1] = '\0';
-    if (access(fileName, F_OK) == 0)
-    {
-        fp = fopen(fileName, "r");
-        if(fp != NULL) {
-            if (fgets(buf, sizeof(buf), fp) != NULL)
-                timeout = atoi(buf);
-            fclose(fp);
-        }
-        if (timeout > 0)
-            return timeout * 1000;
+    fp = fopen(fileName, "r");
+    if(fp != NULL) {
+        if (fgets(buf, sizeof(buf), fp) != NULL)
+            timeout = atoi(buf);
+        fclose(fp);
     }
+    if (timeout > 0)
+        return timeout * 1000;
     return handle->timeoutValues.setTimeout;
 }
 
@@ -287,17 +281,14 @@ uint32_t rbusHandle_FetchGetMultiTimeout(rbusHandle_t handle)
     char fileName[BUF_LEN] = {'\0'};
     snprintf(fileName, BUF_LEN-1, "%s/rbus_%s_timeout_get_wildcard_query", RBUS_TMP_DIRECTORY, __progname);
     fileName[BUF_LEN-1] = '\0';
-    if (access(fileName, F_OK) == 0)
-    {
-        fp = fopen(fileName, "r");
-        if(fp != NULL) {
-            if (fgets(buf, sizeof(buf), fp) != NULL)
-                timeout = atoi(buf);
-            fclose(fp);
-        }
-        if (timeout > 0)
-            return timeout * 1000;
+    fp = fopen(fileName, "r");
+    if(fp != NULL) {
+        if (fgets(buf, sizeof(buf), fp) != NULL)
+            timeout = atoi(buf);
+        fclose(fp);
     }
+    if (timeout > 0)
+        return timeout * 1000;
     return handle->timeoutValues.getMultiTimeout;
 }
 
@@ -310,17 +301,14 @@ uint32_t rbusHandle_FetchSetMultiTimeout(rbusHandle_t handle)
     char fileName[BUF_LEN] = {'\0'};
     snprintf(fileName, BUF_LEN-1, "%s/rbus_%s_timeout_setMulti", RBUS_TMP_DIRECTORY, __progname);
     fileName[BUF_LEN-1] = '\0';
-    if (access(fileName, F_OK) == 0)
-    {
-        fp = fopen(fileName, "r");
-        if(fp != NULL) {
-            if (fgets(buf, sizeof(buf), fp) != NULL)
-                timeout = atoi(buf);
-            fclose(fp);
-        }
-        if (timeout > 0)
-            return timeout * 1000;
+    fp = fopen(fileName, "r");
+    if(fp != NULL) {
+        if (fgets(buf, sizeof(buf), fp) != NULL)
+            timeout = atoi(buf);
+        fclose(fp);
     }
+    if (timeout > 0)
+        return timeout * 1000;
     return handle->timeoutValues.setMultiTimeout;
 }
 

--- a/src/rbus/rbus_subscriptions.c
+++ b/src/rbus/rbus_subscriptions.c
@@ -433,7 +433,6 @@ static bool rbusSubscriptions_isListenerRunning(char const* listener)
 
 static void rbusSubscriptions_loadCache(rbusSubscriptions_t subscriptions)
 {
-    struct stat st;
     long size;
     uint16_t type, length;
     int32_t hasFilter;
@@ -447,12 +446,6 @@ static void rbusSubscriptions_loadCache(rbusSubscriptions_t subscriptions)
     snprintf(filePath, 256, CACHE_FILE_PATH_FORMAT, subscriptions->tmpDir, subscriptions->componentName);
 
     RBUSLOG_INFO("file %s", filePath);
-
-    if(stat(filePath, &st) != 0)
-    {
-        RBUSLOG_DEBUG("file doesn't exist %s", filePath);
-        return;
-    }
 
     file = fopen(filePath, "rb");
     if(!file)


### PR DESCRIPTION


Reason for change: Accessing the file using stat() and access() before fopen()
Test Procedure: as per RDK-58045
Risks: Low