### PR TITLE
RDK-58045 : Addressing the calling risky function bug

### DIFF
--- a/src/rtmessage/rtLog.c
+++ b/src/rtmessage/rtLog.c
@@ -278,7 +278,7 @@ void rtLogPrintf(rtLogLevel level, const char* mod, const char* file, int line, 
   {
     char module[MODULE_BUFFER_SIZE] = {0};
     rdk_LogLevel rdklevel = rdkLogLevelFromrtLogLevel(level);
-    sprintf(module, "LOG.RDK.%s", mod);
+    snprintf(module, MODULE_BUFFER_SIZE, "LOG.RDK.%s", mod);
     RDK_LOG(rdklevel, module, "%s\n", buff);
   }
 #endif

--- a/src/rtmessage/rtRoutingTree.c
+++ b/src/rtmessage/rtRoutingTree.c
@@ -63,8 +63,9 @@ static rtTreeTopic* createTreeTopic(const char* name, rtTreeTopic* parent)
     treeTopic->name = strdup(name);
     if(parent->fullName)
     {
-        treeTopic->fullName = rt_malloc(strlen(parent->fullName) + 1 + strlen(name) + 1);
-        sprintf(treeTopic->fullName, "%s.%s", parent->fullName, name);
+        size_t fullname_length = strlen(parent->fullName) + 1 + strlen(name) + 1;
+        treeTopic->fullName = rt_malloc(fullname_length);
+        snprintf(treeTopic->fullName, fullname_length, "%s.%s", parent->fullName, name);
     }
     else
     {


### PR DESCRIPTION
Reason for change: Calling risky function in createTreeTopic function and rtLogPrintf
Test Procedure: as per RDK-58045
Risks: Low