### PR TITLE
RDK-58045 : Addressing the dead default in switch

### DIFF
--- a/src/rtmessage/rtBase64.c
+++ b/src/rtmessage/rtBase64.c
@@ -121,8 +121,6 @@ rtError rtBase64_encode(const void * in, const unsigned int in_size, unsigned ch
             write_buff[write_index++] = '=';
             break;
 
-        default:
-            rtLog_Error("Unexpected condition.");
     }
     write_buff[write_index] = '\0';
     *out = write_buff;


### PR DESCRIPTION
Reason for change: unsigned int last_group_len = in_size % 3 can only range from 0,1,2
Test Procedure: as per RDK-58045
Risks: Medium