### PR TITLE
RDK-58045 : Addressing the 'Constant' variable guards dead code

### DIFF
--- a/src/rbus/rbus_element.c
+++ b/src/rbus/rbus_element.c
@@ -373,16 +373,9 @@ elementNode* insertElement(elementNode* root, rbusDataElement_t* elem)
     free(name);
     UNLOCK();
 
-    if(ret == 0)
-    {
-        replicateAcrossTableRowInstances(currentNode);
+    replicateAcrossTableRowInstances(currentNode);
 
-        return currentNode;
-    }
-    else
-    {
-        return NULL;
-    }
+    return currentNode;
 }
 
 elementNode* retrieveElement(elementNode* root, const char* elmentName)


### PR DESCRIPTION
Reason for change: local variable ret is assigned once . make it constant throughout its scope
Test Procedure: as per RDK-58045
Risks: Medium