### PR TITLE
RDKB-61485:Reset OutPointers to NULL when RBUS Discover APIs fails

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -1891,7 +1891,8 @@ rbusCoreError_t rbus_discoverWildcardDestinations(const char * expression, int *
     if((NULL == expression) || (NULL == count) || (NULL == destinations))
     {
         RBUSCORELOG_DEBUG("expression/count/destinations pointer is NULL");
-        return RBUSCORE_ERROR_INVALID_PARAM;
+        ret = RBUSCORE_ERROR_INVALID_PARAM;
+        goto exit;
     }
 
     rtMessage_Create(&msg);
@@ -1959,6 +1960,15 @@ rbusCoreError_t rbus_discoverWildcardDestinations(const char * expression, int *
     {
         ret = RBUSCORE_ERROR_MALFORMED_RESPONSE;
     }
+
+exit:
+    if (ret != RBUSCORE_SUCCESS)
+    {
+        if (destinations)
+            *destinations = NULL;
+        if (count)
+            *count = 0;
+    }
     return ret;
 }
 
@@ -1977,7 +1987,8 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
     if((NULL == object) || (NULL == elements) || (NULL == count))
     {
         RBUSCORELOG_DEBUG("Object/elements/count is NULL");
-        return RBUSCORE_ERROR_INVALID_PARAM;
+        ret = RBUSCORE_ERROR_INVALID_PARAM;
+        goto exit;
     }
 
     rtMessage_Create(&msg);
@@ -2040,6 +2051,14 @@ rbusCoreError_t rbus_discoverObjectElements(const char * object, int * count, ch
         ret = RBUSCORE_ERROR_GENERAL;
     }
 
+exit:
+    if (ret != RBUSCORE_SUCCESS)
+    {
+        if (elements)
+           *elements = NULL;
+        if (count)
+           *count = 0;
+    }
     return ret;
 }
 
@@ -2050,17 +2069,16 @@ rbusCoreError_t rbus_discoverElementObjects(const char* element, int * count, ch
     rtMessage msg, rsp;
 
     rtMessage_Create(&msg);
-    if(NULL != element)
-    {
-        rtMessage_SetInt32(msg, RTM_DISCOVERY_COUNT, 1);
-        rtMessage_AddString(msg, RTM_DISCOVERY_ITEMS, element);
-    }
-    else
+
+    if((NULL == element) || (NULL == count) || (NULL == objects))
     {
         RBUSCORELOG_DEBUG("Null entries in element list.");
         rtMessage_Release(msg);
-        return RBUSCORE_ERROR_INVALID_PARAM;
+        ret= RBUSCORE_ERROR_INVALID_PARAM;
+        goto exit;
     }
+    rtMessage_SetInt32(msg, RTM_DISCOVERY_COUNT, 1);
+    rtMessage_AddString(msg, RTM_DISCOVERY_ITEMS, element);
 
     err = rtConnection_SendRequest(g_connection, msg, RTM_DISCOVER_ELEMENT_OBJECTS, &rsp, TIMEOUT_VALUE_FIRE_AND_FORGET);
 
@@ -2116,6 +2134,14 @@ rbusCoreError_t rbus_discoverElementObjects(const char* element, int * count, ch
         ret = RBUSCORE_ERROR_MALFORMED_RESPONSE;
     }
 
+exit:
+    if (ret != RBUSCORE_SUCCESS)
+    {
+        if (objects)
+            *objects = NULL;
+        if (count)
+            *count = 0;
+    }
     return ret;
 }
 
@@ -2127,6 +2153,12 @@ rbusCoreError_t rbus_discoverElementsObjects(int numElements, const char** eleme
     char** array_ptr = NULL;
     int array_count = 0;
 
+    if((NULL == objects) || (NULL == count))
+    {
+        RBUSCORELOG_ERROR("Object/count is NULL");
+        ret = RBUSCORE_ERROR_INVALID_PARAM;
+        goto exit;
+    }
     *count = 0;
 
     rtMessage_Create(&msg);
@@ -2231,6 +2263,15 @@ rbusCoreError_t rbus_discoverElementsObjects(int numElements, const char** eleme
             free(array_ptr);
         }
     }
+
+exit:
+    if (ret != RBUSCORE_SUCCESS)
+    {
+        if (objects)
+           *objects = NULL;
+        if (count)
+           *count = 0;
+    }
     return ret;
 }
 
@@ -2242,6 +2283,13 @@ rbusCoreError_t rbus_discoverRegisteredComponents(int * count, char *** componen
     rtMessage out;
     rtMessage_Create(&out);
     rtMessage_SetInt32(out, "dummy", 0);
+
+    if(count == NULL || components == NULL)
+    {
+        RBUSCORELOG_ERROR("Invalid parameters: count=%p components=%p", count, components);
+        ret = RBUSCORE_ERROR_INVALID_PARAM;
+        goto exit;
+    }
 
     if(NULL == g_connection)
     {
@@ -2297,6 +2345,14 @@ rbusCoreError_t rbus_discoverRegisteredComponents(int * count, char *** componen
         ret = RBUSCORE_ERROR_GENERAL;
     }
 
+exit:
+    if (ret != RBUSCORE_SUCCESS)
+    {
+        if (components)
+            *components = NULL;
+        if (count)
+            *count = 0;
+    }
     rtMessage_Release(out);
     return ret;
 }


### PR DESCRIPTION
Reason for change: To avoid memory leak
Test Procedure: Tested and verified
Priority: P1
Risks: Medium