### PR TITLE
RDKB-61717: set & get APIs for Property ChangeComponent name

### DIFF
--- a/include/rbus.h
+++ b/include/rbus.h
@@ -2082,6 +2082,10 @@ rbusError_t rbusHandle_ConfigSetMultiTimeout(rbusHandle_t handle, uint32_t timeo
  *  @return     RBus error code as defined by rbusError_t.
  */
 rbusError_t rbusHandle_ConfigSubscribeTimeout(rbusHandle_t handle, uint32_t timeout);
+
+rbusError_t rbus_setPropertyChangeComponent(rbusHandle_t handle, char const* elementName, char const* componentName);
+
+rbusError_t rbus_getPropertyChangeComponent(rbusHandle_t handle, char const* elementName, char* componentName);
 /** @} */
 
 #ifdef __cplusplus

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -6555,4 +6555,50 @@ rbusError_t rbus_registerDynamicTableSyncHandler(
     return RBUS_ERROR_SUCCESS;
 }
 
+rbusError_t rbus_setPropertyChangeComponent(
+    rbusHandle_t handle,
+    char const* elementName,
+    char const* componentName)
+{
+
+    struct _rbusHandle* handleInfo;
+    elementNode* node;
+    VERIFY_HANDLE(handle);
+    VERIFY_NULL(elementName);
+
+    handleInfo = (struct _rbusHandle*)handle;
+    node = retrieveElement(handleInfo->elementRoot, elementName);
+    if (!node)
+        return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
+    if (node->type == RBUS_ELEMENT_TYPE_PROPERTY)
+        setPropertyChangeComponent(node, componentName);
+    return RBUS_ERROR_SUCCESS;
+}
+
+rbusError_t rbus_getPropertyChangeComponent(
+    rbusHandle_t handle,
+    char const* elementName,
+    char* componentName)
+{
+    struct _rbusHandle* handleInfo;
+    elementNode* node;
+    VERIFY_HANDLE(handle);
+    VERIFY_NULL(elementName);
+    VERIFY_NULL(componentName);
+
+    handleInfo = (struct _rbusHandle*)handle;
+    node = retrieveElement(handleInfo->elementRoot, elementName);
+    if (!node)
+        return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
+
+    if (node->changeComp)
+    {
+        strncpy(componentName, node->changeComp, RBUS_MAX_NAME_LENGTH - 1);
+    }
+    else
+    {
+        componentName[0] = '\0';
+    }
+    return RBUS_ERROR_SUCCESS;
+}
 /* End of File */


### PR DESCRIPTION
Reason for change: Missing ChangeComponent name in value change event data (In Common Library) 
Signed-off-by: Netaji Panigrahi [Netaji_Panigrahi@comcast.com](mailto:Netaji_Panigrahi@comcast.com)