### PR TITLE
    RDKB-61705:setsockopt(TCP_NODELAY) failed

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -368,7 +368,7 @@ rtConnection_ConnectAndRegister(rtConnection con, rtTime_t* reconnect_time)
 
   if (setsockopt(con->fd, SOL_TCP, TCP_NODELAY, &i, sizeof(i)) < 0)
   {
-    rtLog_Warn("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
+    rtLog_Debug("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
   }
   rtSocketStorage_ToString(&con->remote_endpoint, remote_addr, sizeof(remote_addr), &remote_port);
 


### PR DESCRIPTION


    Reason for change: setsockopt(TCP_NODELAY) failed: Operation not supported warn observed when executed
                       disca in rbuscli interface.
    Test Procedure: Tested and verified
    Priority: P1
    Risks: Medium

    Signed-off-by: Rose Mary Benny <RoseMary_Benny@comcast.com>