### PR TITLE
rtrouted: check return value of setsockopt

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1699,7 +1699,8 @@ rtRouted_AcceptClientConnection(rtListener* listener)
   }
 
   uint32_t one = 1;
-  setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one));
+  if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one)) == -1)
+    rtLog_Warn("setsockopt TCP_NODELAY failed: %s", rtStrError(errno));
 
   rtRouted_RegisterNewClient(fd, &remote_endpoint);
 }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg and @fwph. This change checks the return value of `setsockopt` and logs a warning message if it fails.

This PR complies with RDK LLM usage requirements.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>