### PR TITLE
RDKB-62423 : Use CLOCK_MONOTONIC_RAW across rbus

### DIFF
--- a/src/rtmessage/rtTime.c
+++ b/src/rtmessage/rtTime.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <time.h>
 
-#define RT_CLOCK_ID CLOCK_MONOTONIC
+#define RT_CLOCK_ID CLOCK_MONOTONIC_RAW
 
 rtTime_t* rtTime_Now(rtTime_t* t)
 {

--- a/src/rtmessage/rtrouteBase.c
+++ b/src/rtmessage/rtrouteBase.c
@@ -408,7 +408,7 @@ rtConnectedClient_Read(rtConnectedClient* clnt, rtRouteEntry* myDirectRoute)
         }
 #ifdef ENABLE_ROUTER_BENCHMARKING
         if(clnt->header.flags & rtMessageFlags_Tainted)
-          clock_gettime(CLOCK_MONOTONIC, &g_entry_exit_timestamps[g_timestamp_index][0]);
+          clock_gettime(CLOCK_MONOTONIC_RAW, &g_entry_exit_timestamps[g_timestamp_index][0]);
 #endif
         clnt->bytes_to_read += clnt->header.payload_length;
         clnt->state = rtConnectionState_ReadPayload;
@@ -442,7 +442,7 @@ rtConnectedClient_Read(rtConnectedClient* clnt, rtRouteEntry* myDirectRoute)
 #ifdef ENABLE_ROUTER_BENCHMARKING
         if(clnt->header.flags & rtMessageFlags_Tainted)
         {
-          clock_gettime(CLOCK_MONOTONIC, &g_entry_exit_timestamps[g_timestamp_index][1]);
+          clock_gettime(CLOCK_MONOTONIC_RAW, &g_entry_exit_timestamps[g_timestamp_index][1]);
           if(g_timestamp_index < (MAX_TIMESTAMP_ENTRIES - 1))
             g_timestamp_index++;
         }

--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1591,7 +1591,7 @@ rtConnectedClient_Read(rtConnectedClient* clnt)
         }
 #ifdef ENABLE_ROUTER_BENCHMARKING
         if(clnt->header.flags & rtMessageFlags_Tainted)
-          clock_gettime(CLOCK_MONOTONIC, &g_entry_exit_timestamps[g_timestamp_index][0]);
+          clock_gettime(CLOCK_MONOTONIC_RAW, &g_entry_exit_timestamps[g_timestamp_index][0]);
 #endif
         clnt->bytes_to_read += clnt->header.payload_length;
         clnt->state = rtConnectionState_ReadPayload;
@@ -1625,7 +1625,7 @@ rtConnectedClient_Read(rtConnectedClient* clnt)
 #ifdef ENABLE_ROUTER_BENCHMARKING
         if(clnt->header.flags & rtMessageFlags_Tainted)
         {
-          clock_gettime(CLOCK_MONOTONIC, &g_entry_exit_timestamps[g_timestamp_index][1]);
+          clock_gettime(CLOCK_MONOTONIC_RAW, &g_entry_exit_timestamps[g_timestamp_index][1]);
           if(g_timestamp_index < (MAX_TIMESTAMP_ENTRIES - 1))
             g_timestamp_index++;
         }

--- a/test/core/rbus_perf.cpp
+++ b/test/core/rbus_perf.cpp
@@ -30,7 +30,7 @@
 #include <vector>
 #include <atomic>
 #include <algorithm>
-#define CLOCK_TYPE CLOCK_MONOTONIC
+#define CLOCK_TYPE CLOCK_MONOTONIC_RAW
 
 static void timespec_sub(struct timespec * recent, struct timespec * old, struct timespec *difference)
 {


### PR DESCRIPTION
Reason for change: Use CLOCK_MONOTONIC_RAW across rbus
Test Procedure: Verify the system end to end
Risks: Medium