### PR TITLE
rbuscli: fixup potential memory leak

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -967,7 +967,7 @@ void execute_discover_component_cmd(int argc, char* argv[])
     int index = 0;
     int i;
     int componentCnt = 0;
-    char **pComponentNames;
+    char **pComponentNames = NULL;
     char const* pElementNames[RBUS_CLI_MAX_PARAM] = {0, 0};
 
     if (!verify_rbus_open())
@@ -990,7 +990,6 @@ void execute_discover_component_cmd(int argc, char* argv[])
                 printf ("\tComponent %d: %s\r\n", (i + 1), pComponentNames[i]);
                 free(pComponentNames[i]);
             }
-            free(pComponentNames);
         }
         else
         {
@@ -1001,6 +1000,8 @@ void execute_discover_component_cmd(int argc, char* argv[])
     {
         printf ("Failed to discover components. Error Code = %d\r\n", rc);
     }
+
+    free(pComponentNames);
 }
 
 void execute_discover_elements_cmd(int argc, char *argv[])


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @dnovick and @jweese. There is a corner case where, if `rbus_discoverComponentName` succeeds, but the returned component count is 0, `pComponentNames` will not be freed. This change moves the free of `pComponentNames` to the bottom of the function so it will always be executed. `pComponentNames` is initialized to NULL, so it is safe to free it even if no allocation occurs.

This PR complies with RDK LLM usage requirements.

on-behalf-of: @permanence-ai github-ai@permanence.ai