### PR TITLE
rbuscli: fixup resource leak in subscribe_cmd

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -1974,7 +1974,7 @@ void validate_and_execute_subscribe_cmd (int argc, char *argv[], bool add, bool 
     }
 
     if (!verify_rbus_open())
-        return;    
+        return;
 
     if(!g_subsribeUserData)
        rtList_Create(&g_subsribeUserData);
@@ -2071,6 +2071,14 @@ void validate_and_execute_subscribe_cmd (int argc, char *argv[], bool add, bool 
 exit_error:
         runSteps = __LINE__;
         printf ("Invalid arguments. Please see the help\r\n");
+        if(filterValue)
+        {
+            rbusValue_Release(filterValue);
+        }
+        if(filter)
+        {
+            rbusFilter_Release(filter);
+        }
         rt_free(userData);
         return;
     }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese, @dnovick, and @fwph.

This adds calls to release `filterValue` and `filter` in the `exit_error` block to prevent a resource leak.

This PR complies with RDK LLM usage requirements.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>