### PR TITLE
rbuscli: add null check for argv in construct_input_into_cmds

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -2592,11 +2592,18 @@ static int construct_input_into_cmds(char* buff, int* pargc, char** argv)
     int len = (int)strlen(buff);
     int i, j, quote;
     int argc = 0;
-    argv[argc++] = "rbuscli";
+    if (argv)
+    {
+        argv[argc++] = "rbuscli";
+    }
+    else
+    {
+        argc++;
+    }
     runSteps = __LINE__;
     for(i = 0; i < len; ++i)
     {
-        quote = 0;    
+        quote = 0;
         while(i < len && (buff[i] == ' ' || buff[i] == '\t'))
             ++i;
         if(i == len)


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph.

This adds a null check for `argv` before assigning to `argv[argc++]`. This prevents a null pointer dereference if `argv` is null. This is consistent with the check on argv later in the function.

This PR complies with RDK LLM usage requirements.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>