### PR TITLE
rbus: fixup unreachable code in rbus_open

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3021,7 +3021,7 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
     if (rbusHandle_TimeoutValuesInit(tmpHandle) != 0)
     {
         RBUSLOG_ERROR("(%s): rbusHandle_TimeoutValuesInit failed", componentName);
-        goto exit_error2;
+        goto exit_error3;
     }
     tmpHandle->componentName = strdup(componentName);
     tmpHandle->componentId = ++sLastComponentId;
@@ -3049,6 +3049,8 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
 
     RBUSLOG_INFO(" rbus open (%s) success", componentName);
     return RBUS_ERROR_SUCCESS;
+
+exit_error3:
 
     if((err = rbus_unregisterObj(componentName)) != RBUSCORE_SUCCESS)
         RBUSLOG_ERROR("(%s): unregisterObj error %d", componentName, err);


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @dnovick and @jweese.

In the original code, the failure cases of both `rbus_registerObj` and `rbusHandle_TimeoutValuesInit` use `goto exit_error2`. Combined with the return on L3047, this renders the call to `rbus_unregisterObj` unreachable. If `rbus_registerObj` succeeds but `rbusHanlde_TimeoutValuesInit` fails, the object is never unregistered. It seems the intent should be to unregister `componentName` if registration succeeds but a later operation fails. This change adds another label right before the unreachable `rbus_unregisterObj` call and jumps there in the case that `rbusHandle_TimeoutValuesInit` fails. All other behavior is unaffected: if registration fails we jump to `exit_error2` as before; if both calls succeed, we continue onto the success path.

This PR complies with RDK LLM usage requirements.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>