### PR TITLE
rbuscli: fixup unreachable code in hints function

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -2905,7 +2905,7 @@ char *hints(const char *buf, int *color, int *bold) {
             hint = " type(string,int,uint,boolean,...) value";
         }
     }
-    else if(num == 3)
+    else if(num == 4)
     {
         runSteps = __LINE__;
         if(strcmp(tokens[0], "method_va") == 0)


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese.

The condition else if (num == 3) is repeated twice, making the second block unreachable. Since the intent of the conditions is to switch on the number of arguments counted, this change updates the second condition to compare num to 4. The expected value of hint in that block is consistent with num being 4 as opposed to 3.

This PR complies with RDK LLM usage requirements.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>