### PR TITLE
rbus: fix coverity RESOURCE_LEAK in testGetProperty

### DIFF
--- a/unittests/rbusPropertyTest.cpp
+++ b/unittests/rbusPropertyTest.cpp
@@ -395,7 +395,9 @@ TEST(rbusPropertyTest, testGetProperty)
   rbusProperty_t prop2 = rbusProperty_InitProperty("MyProp2",prop);
   rbusProperty_SetProperty(prop2, prop1);
   EXPECT_EQ(rbusProperty_GetProperty(prop2), prop1);
-  rbusProperty_Releases(3, prop,prop1,prop2);
+  /* Explicitly release prop2 to prevent resource leak detected by Coverity */
+  rbusProperty_Release(prop2);
+  rbusProperty_Releases(2, prop,prop1);
 }
 
 TEST(rbusPropertyTest, testGetObject)


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK Issue #108

** (
### Coverity Defect Fixed:
- **File**: `unittests/rbusPropertyTest.cpp`
- **Line**: 399
- **Function**: `testGetProperty()`
- **Issue**: `prop2` allocated by `rbusProperty_InitProperty()` not properly freed

### Root Cause:
`rbusProperty_InitProperty()` allocates heap memory for `prop2`. The variadic function `rbusProperty_Releases(3, prop, prop1, prop2)` cannot be statically verified by Coverity to properly free all arguments, causing a resource leak.

### Solution:
```cpp
/* Explicitly release prop2 to prevent resource leak */
rbusProperty_Release(prop2);
rbusProperty_Releases(2, prop, prop1);
```

### Why This Fix:
- ✅ Minimal code changes
- ✅ Matches existing patterns
- ✅ Explicit cleanup Coverity can verify
- ✅ Maintains test functionality

### Changes:
- Modified: `unittests/rbusPropertyTest.cpp`
- +3 lines, -1 line