### PR TITLE
rbus: fix coverity RESOURCE_LEAK in testGetProperty

### DIFF
--- a/unittests/rbusPropertyTest.cpp
+++ b/unittests/rbusPropertyTest.cpp
@@ -395,7 +395,9 @@ TEST(rbusPropertyTest, testGetProperty)
   rbusProperty_t prop2 = rbusProperty_InitProperty("MyProp2",prop);
   rbusProperty_SetProperty(prop2, prop1);
   EXPECT_EQ(rbusProperty_GetProperty(prop2), prop1);
-  rbusProperty_Releases(3, prop,prop1,prop2);
+  /* Explicitly release prop2 to prevent resource leak detected by Coverity */
+  rbusProperty_Release(prop2);
+  rbusProperty_Releases(2, prop,prop1);
 }
 
 TEST(rbusPropertyTest, testGetObject)


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in testGetProperty

In the original code, rbusProperty_InitProperty() allocates heap memory for prop2, but the variadic function rbusProperty_Releases(3, prop, prop1, prop2) cannot be statically verified by Coverity to properly free all arguments. This causes Coverity to flag a potential resource leak at line 399 when the test function exits.

This change adds an explicit rbusProperty_Release(prop2) call before the variadic function, allowing Coverity to verify the resource is properly freed. The remaining properties are then released using rbusProperty_Releases(2, prop, prop1). All other behavior is unaffected.

Coverity Defect: Line 399 in `unittests/rbusPropertyTest.cpp`, function `testGetProperty()`
Coverity Issue ID: 108 (from Confluence wiki)