### PR TITLE
rbus: fix coverity RESOURCE_LEAK in testSerialize

### DIFF
--- a/test/rbus/consumer/filter.c
+++ b/test/rbus/consumer/filter.c
@@ -64,6 +64,9 @@ static void testSerialize(rbusFilter_t f1)
     if(!file)
     {
         TEST(file != NULL);
+        /* Free allocated buffers before returning to prevent resource leak */
+        rbusBuffer_Destroy(buffOut);
+        rbusBuffer_Destroy(buffIn);
         return;
     }
     fseek(file, 0, SEEK_END);


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in testSerialize

In the original code, rbusBuffer_Create() allocates memory for buffOut (line 51) and buffIn (line 62). When the second fopen() call fails at line 64, the function returns at line 67 without freeing these allocated buffers, causing a resource leak.

This change adds explicit rbusBuffer_Destroy() calls for both buffOut and buffIn before the early return, matching the cleanup pattern used at the end of the function (lines 90-91). All other behavior is unaffected.

Coverity Defect: Line 67 in `test/rbus/consumer/filter.c`, function `testSerialize()`
Coverity Issue ID: 109 (from Confluence wiki)