### PR TITLE
rbus: fix coverity RESOURCE_LEAK in rbusObject_initFromMessage

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -757,6 +757,10 @@ void rbusObject_initFromMessage(rbusObject_t* obj, rbusMessage msg)
     rbusProperty_Release(prop);
     rbusObject_SetChildren(*obj, children);
     rbusObject_Release(children);
+    
+    /* Free the name string allocated by rbusMessage_GetString */
+    if(name)
+        free((void*)name);
 }
 
 void rbusValue_appendToMessage(char const* name, rbusValue_t value, rbusMessage msg)


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in rbusObject_initFromMessage

In the original code, rbusMessage_GetString() allocates memory for the name string at line 724. This string is passed to rbusObject_Init() at line 754 but is never freed before the function returns at line 760, causing a resource leak.

This change adds an explicit free() call for the name string after all object initialization is complete and before the function returns. The cleanup follows the same pattern used for other allocated resources (prop and children) in the function.

Coverity Defect: Line 754 in `src/rbus/rbus.c`, function `rbusObject_initFromMessage()`
Coverity Issue ID: 110 (from Confluence wiki)