### PR TITLE
rbus: fix coverity RESOURCE_LEAK in rbus_getExt

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3679,7 +3679,7 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
         else
         {
             int numDestinations = 0;
-            char** destinations;
+            char** destinations = NULL;
             //int length = strlen(pParamNames[0]);
 
             err = rbus_discoverWildcardDestinations(pParamNames[0], &numDestinations, &destinations);
@@ -3692,7 +3692,9 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
                 {
                     RBUSLOG_DEBUG("It is possibly a table entry from single component.");
                     /* Free destinations allocated by rbus_discoverWildcardDestinations */
-                    free(destinations);
+                    if (destinations != NULL)
+                        free(destinations);
+                    return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
                 }
                 else
                 {

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3691,6 +3691,8 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
                 if (0 == numDestinations)
                 {
                     RBUSLOG_DEBUG("It is possibly a table entry from single component.");
+                    /* Free destinations allocated by rbus_discoverWildcardDestinations */
+                    free(destinations);
                 }
                 else
                 {


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in rbus_getExt

In the original code, when `rbus_discoverWildcardDestinations()` returns successfully but with `numDestinations == 0`, the function enters the if block at line 3691 and exits at line 3788 without freeing the `destinations` array that was allocated at line 3685. This causes a memory leak.

The fix adds an explicit `free(destinations)` call in the `numDestinations == 0` case to match the cleanup pattern used in the else block (lines 3769-3771) where destinations is properly freed after use.

Coverity Defect: Line 3788 in `src/rbus/rbus.c`, function `rbus_getExt()`
Coverity Issue ID: 138 (from Confluence wiki)