### PR TITLE
rtmessage: fix coverity RESOURCE_LEAK in rtConnection_CreateInternal

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -549,10 +549,25 @@ rtConnection_CreateInternal(rtConnection* con, char const* application_name, cha
   c->send_buffer_in_use = 0;
   c->send_buffer = (uint8_t *) rt_try_malloc(RTMSG_SEND_BUFFER_SIZE);
   if(!c->send_buffer)
+  {
+    pthread_mutex_destroy(&c->mutex);
+    pthread_mutex_destroy(&c->callback_message_mutex);
+    pthread_mutex_destroy(&c->reconnect_mutex);
+    pthread_cond_destroy(&c->callback_message_cond);
+    free(c);
     return rtErrorFromErrno(ENOMEM);
+  }
   c->recv_buffer = (uint8_t *) rt_try_malloc(RTMSG_SEND_BUFFER_SIZE);
   if(!c->recv_buffer)
+  {
+    free(c->send_buffer);
+    pthread_mutex_destroy(&c->mutex);
+    pthread_mutex_destroy(&c->callback_message_mutex);
+    pthread_mutex_destroy(&c->reconnect_mutex);
+    pthread_cond_destroy(&c->callback_message_cond);
+    free(c);
     return rtErrorFromErrno(ENOMEM);
+  }
   c->recv_buffer_capacity = RTMSG_SEND_BUFFER_SIZE;
   c->sequence_number = 1;
 #ifdef C11_ATOMICS_SUPPORTED

--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -552,8 +552,8 @@ rtConnection_CreateInternal(rtConnection* con, char const* application_name, cha
   {
     pthread_mutex_destroy(&c->mutex);
     pthread_mutex_destroy(&c->callback_message_mutex);
-    pthread_mutex_destroy(&c->reconnect_mutex);
     pthread_cond_destroy(&c->callback_message_cond);
+    pthread_mutex_destroy(&c->reconnect_mutex);
     free(c);
     return rtErrorFromErrno(ENOMEM);
   }
@@ -563,8 +563,8 @@ rtConnection_CreateInternal(rtConnection* con, char const* application_name, cha
     free(c->send_buffer);
     pthread_mutex_destroy(&c->mutex);
     pthread_mutex_destroy(&c->callback_message_mutex);
-    pthread_mutex_destroy(&c->reconnect_mutex);
     pthread_cond_destroy(&c->callback_message_cond);
+    pthread_mutex_destroy(&c->reconnect_mutex);
     free(c);
     return rtErrorFromErrno(ENOMEM);
   }


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in rtConnection_CreateInternal

In the original code, when `send_buffer` allocation fails at line 551 or `recv_buffer` allocation fails at line 554, the function returns immediately without cleaning up previously allocated resources. This causes multiple resource leaks:

- Memory leak: connection structure `c` (allocated at line 524)
- Memory leak: `send_buffer` (when recv_buffer allocation fails)
- Resource leak: 3 pthread mutexes (initialized at lines 533-535)
- Resource leak: 1 pthread condition variable (initialized at line 541)

The fix adds proper cleanup before returning on allocation failures:
1. Destroy all initialized mutexes and condition variables
2. Free allocated buffers
3. Free the connection structure

This ensures no resources are leaked when allocation failures occur during connection initialization.

Coverity Defect: Line 555 in `src/rtmessage/rtConnection.c`, function `rtConnection_CreateInternal()`
Coverity Issue ID: 111 (from Confluence wiki)