### PR TITLE
rbuscli: fix coverity RESOURCE_LEAK in discovery commands

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -967,7 +967,7 @@ void execute_discover_component_cmd(int argc, char* argv[])
     int index = 0;
     int i;
     int componentCnt = 0;
-    char **pComponentNames;
+    char **pComponentNames = NULL;
     char const* pElementNames[RBUS_CLI_MAX_PARAM] = {0, 0};
 
     if (!verify_rbus_open())
@@ -1000,6 +1000,11 @@ void execute_discover_component_cmd(int argc, char* argv[])
     else
     {
         printf ("Failed to discover components. Error Code = %d\r\n", rc);
+        if (pComponentNames != NULL)
+        {
+            free(pComponentNames);
+        }
+        return;
     }
 }
 
@@ -1009,7 +1014,7 @@ void execute_discover_elements_cmd(int argc, char *argv[])
     int numOfInputParams = argc - 2;
     bool nextLevel = true;
     int numElements = 0;
-    char** pElementNames; // FIXME: every component will have more than RBUS_CLI_MAX_PARAM elements right?
+    char** pElementNames = NULL; // FIXME: every component will have more than RBUS_CLI_MAX_PARAM elements right?
 
     if (!verify_rbus_open())
         return;
@@ -1045,6 +1050,11 @@ void execute_discover_elements_cmd(int argc, char *argv[])
     else
     {
         printf ("Failed to discover elements. Error Code = %d\r\n", rc);
+        if (pElementNames != NULL)
+        {
+            free(pElementNames);
+        }
+        return;
     }
 }
 
@@ -1052,7 +1062,7 @@ void execute_discover_wildcard_dests_cmd(int argc, char* argv[])
 {
     rbusCoreError_t rc = RBUSCORE_SUCCESS;
     int numDestinations = 0;
-    char** destinations;
+    char** destinations = NULL;
 
     (void)argc;
     (void)argv;
@@ -1089,6 +1099,11 @@ void execute_discover_wildcard_dests_cmd(int argc, char* argv[])
     else
     {
         printf ("Failed to discover components. Error Code = %d\r\n", rc);
+        if (destinations != NULL)
+        {
+            free(destinations);
+        }
+        return;
     }
 }
 


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in Discovery Commands

### Coverity Issues Fixed

This PR fixes three related Coverity RESOURCE_LEAK defects in `utils/rbuscli/rbuscli.c`:

- **Coverity CID 112** (line 1004): `execute_discover_component_cmd`
- **Coverity CID 113** (line 1093): `execute_discover_wildcard_dests_cmd`
- **Coverity CID 114** (line 1049): `execute_discover_elements_cmd`

> **Note:** These are Coverity defect IDs, not GitHub issue numbers.

### Root Cause

All three functions had similar resource leak patterns:

1. **CID 112**: Memory allocated by `rbus_discoverComponentName()` was not freed in the error path
2. **CID 113**: Uninitialized `destinations` pointer + no cleanup when `rbus_discoverWildcardDestinations()` fails
3. **CID 114**: Memory potentially allocated by `rbus_discoverComponentDataElements()` even when `numElements == 0`, not freed in error path

### Changes Made

For each function, the fix includes:

1. **Initialize pointers to NULL** to prevent undefined behavior
   ```c
   char **pComponentNames = NULL;
   char **pElementNames = NULL;
   char **destinations = NULL;
   ```

2. **Add cleanup in error paths** to prevent memory leaks
   ```c
   if (pointer != NULL)
   {
       free(pointer);
   }
   ```

3. **Add return statements** to prevent fall-through to unintended code paths

---

**Coverity Defect Details:**
- **CID 112**: Line 1004 in `utils/rbuscli/rbuscli.c`, function `execute_discover_component_cmd()`
- **CID 113**: Line 1093 in `utils/rbuscli/rbuscli.c`, function `execute_discover_wildcard_dests_cmd()`
- **CID 114**: Line 1049 in `utils/rbuscli/rbuscli.c`, function `execute_discover_elements_cmd()`

**Coverity Checker**: RESOURCE_LEAK