### PR TITLE
test: fix coverity RESOURCE_LEAK in testValue_InitGetSetByType

### DIFF
--- a/test/rbus/consumer/propertyAPI.c
+++ b/test/rbus/consumer/propertyAPI.c
@@ -402,7 +402,7 @@ void testValue_InitGetSetByType()
     rbusProperty_Release(vobj);
     rbusProperty_Release(prop);
     rbusProperty_Release(prop2);
-    
+
     // Release objects individually
     rbusObject_Release(obj);
     rbusObject_Release(obj2);

--- a/test/rbus/consumer/propertyAPI.c
+++ b/test/rbus/consumer/propertyAPI.c
@@ -383,8 +383,29 @@ void testValue_InitGetSetByType()
     TEST(rbusProperty_GetProperty(vprop) != NULL && rbusProperty_GetName(rbusProperty_GetProperty(vprop)) && !strcmp(rbusProperty_GetName(rbusProperty_GetProperty(vprop)), "MyProp2"));
     TEST(rbusProperty_GetObject(vobj) != NULL && rbusObject_GetName(rbusProperty_GetObject(vobj)) && !strcmp(rbusObject_GetName(rbusProperty_GetObject(vobj)), "MyObj2"));
 
-    rbusProperty_Releases(17, vbtrue, vbfalse, vi16_n1234, vu16_4321, vi32_689013, vu32_856712, vi64_987654321213, vu64_987654321213, vf32_354dot678, vf64_789dot4738291023, vtv, vs, vbytes, vprop, vobj, prop, prop2);
-    rbusObject_Releases(2, obj, obj2);
+    // Release all properties individually for Coverity static analysis
+    // (Coverity cannot track variadic function arguments)
+    rbusProperty_Release(vbtrue);
+    rbusProperty_Release(vbfalse);
+    rbusProperty_Release(vi16_n1234);
+    rbusProperty_Release(vu16_4321);
+    rbusProperty_Release(vi32_689013);
+    rbusProperty_Release(vu32_856712);
+    rbusProperty_Release(vi64_987654321213);
+    rbusProperty_Release(vu64_987654321213);
+    rbusProperty_Release(vf32_354dot678);
+    rbusProperty_Release(vf64_789dot4738291023);
+    rbusProperty_Release(vtv);
+    rbusProperty_Release(vs);
+    rbusProperty_Release(vbytes);
+    rbusProperty_Release(vprop);
+    rbusProperty_Release(vobj);
+    rbusProperty_Release(prop);
+    rbusProperty_Release(prop2);
+    
+    // Release objects individually
+    rbusObject_Release(obj);
+    rbusObject_Release(obj2);
 }
 
 void testPropertyAPI(rbusHandle_t handle, int* countPass, int* countFail)


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in testValue_InitGetSetByType

### Coverity Issues Fixed

This PR fixes **19 Coverity RESOURCE_LEAK defects** in `test/rbus/consumer/propertyAPI.c`:

**Coverity CIDs:** 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135

- **Line:** 388 (all issues at same line)

> **Note:** These are Coverity defect IDs, not GitHub issue numbers.

### Root Cause

**Coverity static analysis limitation with variadic functions:**

The original code used variadic cleanup functions:
```c
rbusProperty_Releases(17, vbtrue, vbfalse, vi16_n1234, ...);
rbusObject_Releases(2, obj, obj2);
```

These functions **properly release all resources**, but Coverity's data flow analysis cannot track resource cleanup through variadic functions (`...`). 

**Why this happens:**
- Variadic functions use `va_arg()` to iterate through arguments
- Static analyzers cannot determine which specific variables map to which `va_arg()` calls
- This causes false positive resource leak warnings
- This is a **known limitation** of static analysis tools

**The implementation** (from `src/rbus/rbus_property.c`):
```c
void rbusProperty_Releases(int count, ...) {
    va_list vl;
    va_start(vl, count);
    for(i = 0; i < count; ++i) {
        rbusProperty_t prop = va_arg(vl, rbusProperty_t);
        if(prop)
            rtRetainable_release(prop, rbusProperty_Destroy);
    }
    va_end(vl);
}
```

Coverity cannot trace which of the 17 parameters are released by which `va_arg()` call.

### Changes Made

Replaced variadic calls with individual release calls:

**Before:**
```c
rbusProperty_Releases(17, vbtrue, vbfalse, vi16_n1234, vu16_4321, ...);
rbusObject_Releases(2, obj, obj2);
```

**After:**
```c
// Release all properties individually for Coverity static analysis
// (Coverity cannot track variadic function arguments)
rbusProperty_Release(vbtrue);
rbusProperty_Release(vbfalse);
rbusProperty_Release(vi16_n1234);
rbusProperty_Release(vu16_4321);
// ... 13 more ...
rbusProperty_Release(prop);
rbusProperty_Release(prop2);

// Release objects individually
rbusObject_Release(obj);
rbusObject_Release(obj2);
```

### Impact

- ✅ **Functionally equivalent** - Same cleanup behavior
- ✅ **Makes cleanup explicit** for static analysis
- ✅ **Fixes all 19 Coverity issues** (CID 117-135)
- ✅ **No performance impact** - Same number of release calls
- ✅ **Better code clarity** - Explicit is better than implicit

### Why 19 Issues?

- 17 `rbusProperty_t` objects
- 2 `rbusObject_t` objects
- **Total: 19 resources** = **19 Coverity CIDs**

Each resource was flagged separately because Coverity couldn't verify it was released.

---

**Technical Note:** This is not a bug in the original code - the variadic functions work correctly. This change is purely to satisfy static analysis tools that cannot trace variadic function arguments.

---

**Coverity Defect Details:**
- **CIDs:** 117-135 (19 issues)
- **Line:** 388 in `test/rbus/consumer/propertyAPI.c`
- **Coverity Checker:** RESOURCE_LEAK