### PR TITLE
tests: fix resource leak in TokenChain tests

### DIFF
--- a/unittests/rbusTokenTest.cpp
+++ b/unittests/rbusTokenTest.cpp
@@ -42,7 +42,7 @@ TEST(rbusTokenTest, negtestToken2)
   EXPECT_EQ(tokens,nullptr);
 
   free(registryElem);
-  free(tokens);
+  TokenChain_destroy(tokens);
 }
 
 TEST(rbusTokenTest, negtestToken3)
@@ -55,7 +55,7 @@ TEST(rbusTokenTest, negtestToken3)
   EXPECT_EQ(tokens,nullptr);
 
   free(registryElem);
-  free(tokens);
+  TokenChain_destroy(tokens);
 }
 
 TEST(rbusTokenTest, negtestToken4)
@@ -72,7 +72,7 @@ TEST(rbusTokenTest, negtestToken4)
 
   free(registryElem->parent);
   free(registryElem);
-  free(tokens);
+  TokenChain_destroy(tokens);
 }
 
 TEST(rbusTokenTest, negtestToken5)
@@ -88,5 +88,5 @@ TEST(rbusTokenTest, negtestToken5)
 
   free(registryElem->parent);
   free(registryElem);
-  free(tokens);
+  TokenChain_destroy(tokens);
 }


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in TokenChain Tests

### Coverity Issue Fixed

**Coverity CID 137**

### Root Cause

Test cases were incorrectly using `free(tokens)` instead of `TokenChain_destroy(tokens)`.

### Changes

Fixed 4 test cases in `rbusTokenTest.cpp`:
- negtestToken2 (line 45)
- negtestToken3 (line 58)
- negtestToken4 (line 75)
- negtestToken5 (line 91)

### Impact

✅ Fixes memory leak in test cases
✅ Uses correct API for TokenChain cleanup
✅ Consistent with production code usage
✅ NULL-safe cleanup