### PR TITLE
test: fix coverity RESOURCE_LEAK in rbusTestProvider (v2)

### DIFF
--- a/test/rbus/provider/rbusTestProvider.c
+++ b/test/rbus/provider/rbusTestProvider.c
@@ -384,8 +384,17 @@ rbusError_t addTable2RowHandler(TableNode* tableNode, char const* alias, uint32_
         return err;
 
     /*add properties and tables to the new row object*/
-    createTableNode((Node*)rowNode, "Table3", addTable3RowHandler);
-    createPropertyNode((Node*)rowNode, "data");
+    if(!createTableNode((Node*)rowNode, "Table3", addTable3RowHandler))
+    {
+        destroyTableRowNode(rowNode);
+        return RBUS_ERROR_OUT_OF_RESOURCES;
+    }
+    
+    if(!createPropertyNode((Node*)rowNode, "data"))
+    {
+        destroyTableRowNode(rowNode);
+        return RBUS_ERROR_OUT_OF_RESOURCES;
+    }
 
     return RBUS_ERROR_SUCCESS;
 }
@@ -401,8 +410,17 @@ rbusError_t addTable1RowHandler(TableNode* tableNode, char const* alias, uint32_
         return err;
 
     /*add properties and tables to the new row object*/
-    createTableNode((Node*)rowNode, "Table2", addTable2RowHandler);
-    createPropertyNode((Node*)rowNode, "data");
+    if(!createTableNode((Node*)rowNode, "Table2", addTable2RowHandler))
+    {
+        destroyTableRowNode(rowNode);
+        return RBUS_ERROR_OUT_OF_RESOURCES;
+    }
+    
+    if(!createPropertyNode((Node*)rowNode, "data"))
+    {
+        destroyTableRowNode(rowNode);
+        return RBUS_ERROR_OUT_OF_RESOURCES;
+    }
 
     return RBUS_ERROR_SUCCESS;
 }

--- a/test/rbus/provider/rbusTestProvider.c
+++ b/test/rbus/provider/rbusTestProvider.c
@@ -386,13 +386,13 @@ rbusError_t addTable2RowHandler(TableNode* tableNode, char const* alias, uint32_
     /*add properties and tables to the new row object*/
     if(!createTableNode((Node*)rowNode, "Table3", addTable3RowHandler))
     {
-        destroyTableRowNode(rowNode);
+        destroyNode((Node*)rowNode);
         return RBUS_ERROR_OUT_OF_RESOURCES;
     }
     
     if(!createPropertyNode((Node*)rowNode, "data"))
     {
-        destroyTableRowNode(rowNode);
+        destroyNode((Node*)rowNode);
         return RBUS_ERROR_OUT_OF_RESOURCES;
     }
 
@@ -412,13 +412,13 @@ rbusError_t addTable1RowHandler(TableNode* tableNode, char const* alias, uint32_
     /*add properties and tables to the new row object*/
     if(!createTableNode((Node*)rowNode, "Table2", addTable2RowHandler))
     {
-        destroyTableRowNode(rowNode);
+        destroyNode((Node*)rowNode);
         return RBUS_ERROR_OUT_OF_RESOURCES;
     }
     
     if(!createPropertyNode((Node*)rowNode, "data"))
     {
-        destroyTableRowNode(rowNode);
+        destroyNode((Node*)rowNode);
         return RBUS_ERROR_OUT_OF_RESOURCES;
     }
 


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in rbusTestProvider

**Improved fix with enhanced bot validation. Supersedes PR #391.**

### Coverity Issues

This PR fixes two RESOURCE_LEAK issues:
- **CID 106:** Line 387, function `addTable2RowHandler`
- **CID 107:** Line 404, function `addTable1RowHandler`

### Root Cause

Resource leak occurs when `createTableRowNode()` successfully allocates a `TableRowNode`, but subsequent calls to `createTableNode()` or `createPropertyNode()` fail. The allocated `rowNode` is not freed, causing a memory leak.

### Changes

**addTable2RowHandler (CID 106):**
- Add NULL check for `createTableNode()` result
- Add NULL check for `createPropertyNode()` result
- Call `destroyNode()` and return error on failure

**addTable1RowHandler (CID 107):**
- Add NULL check for `createTableNode()` result
- Add NULL check for `createPropertyNode()` result
- Call `destroyNode()` and return error on failure

### Impact

✅ Prevents memory leak when node creation fails
✅ Proper error handling with cleanup
✅ Returns appropriate error code (`RBUS_ERROR_OUT_OF_RESOURCES`)

Supersedes: #391