### PR TITLE
rbus: fix coverity RESOURCE_LEAK in src/rbus/rbus.c

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -718,7 +718,7 @@ void rbusObject_initFromMessage(rbusObject_t* obj, rbusMessage msg)
     char const* name = NULL;
     int type = 0;
     int numChild = 0;
-    rbusProperty_t prop;
+    rbusProperty_t prop = NULL;
     rbusObject_t children=NULL, previous=NULL;
 
     rbusMessage_GetString(msg, &name);
@@ -3679,7 +3679,7 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
         else
         {
             int numDestinations = 0;
-            char** destinations;
+            char** destinations = NULL;
             //int length = strlen(pParamNames[0]);
 
             err = rbus_discoverWildcardDestinations(pParamNames[0], &numDestinations, &destinations);
@@ -3758,7 +3758,17 @@ rbusError_t rbus_getExt(rbusHandle_t handle, int paramCount, char const** pParam
                         if (errorcode != RBUS_ERROR_SUCCESS)
                         {
                             RBUSLOG_WARN("Failed to get the data from %s Component", destinations[i]);
-                            break;
+                            /* Cleanup and return to prevent resource leak */
+                            for(int j = 0; j < numDestinations; j++)
+                                free(destinations[j]);
+                            free(destinations);
+                            /* Return directly to skip normal cleanup path */
+                            if (*retProperties != NULL)
+                            {
+                                RBUSLOG_WARN("Query for expression %s was partially successful", pParamNames[0]);
+                                return RBUS_ERROR_SUCCESS;
+                            }
+                            return errorcode;
                         }
                         else
                         {


### PR DESCRIPTION
## Fix Coverity RESOURCE_LEAK in src/rbus/rbus.c

**Improved fix with enhanced bot validation. Supersedes PR #396 and #408.**

### Coverity Issues

This PR fixes two RESOURCE_LEAK issues in `src/rbus/rbus.c`:
- **CID 110:** Line 754, function `rbusObject_initFromMessage`
- **CID 138:** Line 3788, function `rbus_getExt`

### Root Cause

**CID 110:**
The `prop` variable was uninitialized. If `rbusPropertyList_initFromMessage` fails to set `prop`, the `rbusProperty_Release(prop)` call would operate on an uninitialized pointer, causing undefined behavior.

**CID 138:**
The `destinations` pointer was uninitialized and leaked when error occurred. The `break` statement exited the loop but execution continued to cleanup code, causing potential use-after-free.

### Changes

**CID 110 Fix:**
```c
rbusProperty_t prop = NULL;  // Initialize to NULL
```

**CID 138 Fix:**
1. Initialize `destinations = NULL`
2. Add cleanup before error return
3. Return directly instead of break

### Impact

✅ Prevents undefined behavior from uninitialized pointers
✅ Prevents memory leak on error path
✅ Prevents use-after-free in cleanup code

Supersedes: #396, #408