### PR TITLE
rbus: fixup null pointer dereference in rbusEvent_SubscribeExRawData

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5633,16 +5633,15 @@ rbusError_t rbusEvent_SubscribeExRawData(
                 {
                     RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
                     errorcode = RBUS_ERROR_INVALID_STATE;
+                    HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);
+                    break;
                 }
-                else
+                memset(rawDataTopic, '\0', strlen(rawDataTopic));
+                snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
+                errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+                if(errorcode != RBUS_ERROR_SUCCESS)
                 {
-                    memset(rawDataTopic, '\0', strlen(rawDataTopic));
-                    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
-                    errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
-                    if(errorcode != RBUS_ERROR_SUCCESS)
-                    {
-                        RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
-                    }
+                    RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
                 }
             }
             else
@@ -5652,16 +5651,15 @@ rbusError_t rbusEvent_SubscribeExRawData(
                 {
                     RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
                     errorcode = RBUS_ERROR_INVALID_STATE;
+                    HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);
+                    break;
                 }
-                else
+                snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
+                errorcode = rbusMessage_AddListener(handle, rawDataTopic,
+                        _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+                if(errorcode != RBUS_ERROR_SUCCESS)
                 {
-                    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
-                    errorcode = rbusMessage_AddListener(handle, rawDataTopic,
-                            _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
-                    if(errorcode != RBUS_ERROR_SUCCESS)
-                    {
-                        RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
-                    }
+                    RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
                 }
             }
             HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5633,15 +5633,16 @@ rbusError_t rbusEvent_SubscribeExRawData(
                 {
                     RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
                     errorcode = RBUS_ERROR_INVALID_STATE;
-                    HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);
-                    break;
                 }
-                memset(rawDataTopic, '\0', strlen(rawDataTopic));
-                snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
-                errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
-                if(errorcode != RBUS_ERROR_SUCCESS)
+                else
                 {
-                    RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    memset(rawDataTopic, '\0', strlen(rawDataTopic));
+                    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
+                    errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+                    if(errorcode != RBUS_ERROR_SUCCESS)
+                    {
+                        RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    }
                 }
             }
             else
@@ -5651,15 +5652,16 @@ rbusError_t rbusEvent_SubscribeExRawData(
                 {
                     RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
                     errorcode = RBUS_ERROR_INVALID_STATE;
-                    HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);
-                    break;
                 }
-                snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
-                errorcode = rbusMessage_AddListener(handle, rawDataTopic,
-                        _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
-                if(errorcode != RBUS_ERROR_SUCCESS)
+                else
                 {
-                    RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
+                    errorcode = rbusMessage_AddListener(handle, rawDataTopic,
+                            _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+                    if(errorcode != RBUS_ERROR_SUCCESS)
+                    {
+                        RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    }
                 }
             }
             HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5629,23 +5629,39 @@ rbusError_t rbusEvent_SubscribeExRawData(
                         RBUSLOG_WARN("rbusMessage_RemoveListener:%d", errorcode);
                     }
                 }
-                memset(rawDataTopic, '\0', strlen(rawDataTopic));
-                snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
-                errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
-                if(errorcode != RBUS_ERROR_SUCCESS)
+                if(!subInternal)
                 {
-                    RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
+                    errorcode = RBUS_ERROR_INVALID_STATE;
+                }
+                else
+                {
+                    memset(rawDataTopic, '\0', strlen(rawDataTopic));
+                    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
+                    errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+                    if(errorcode != RBUS_ERROR_SUCCESS)
+                    {
+                        RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    }
                 }
             }
             else
             {
                 subInternal = rbusEventSubscription_find(handleInfo->eventSubs, subscription[i].eventName, subscription[i].filter, subscription[i].interval, subscription[i].duration, true);
-                snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
-                errorcode = rbusMessage_AddListener(handle, rawDataTopic,
-                        _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
-                if(errorcode != RBUS_ERROR_SUCCESS)
+                if(!subInternal)
                 {
-                    RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
+                    errorcode = RBUS_ERROR_INVALID_STATE;
+                }
+                else
+                {
+                    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
+                    errorcode = rbusMessage_AddListener(handle, rawDataTopic,
+                            _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+                    if(errorcode != RBUS_ERROR_SUCCESS)
+                    {
+                        RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
+                    }
                 }
             }
             HANDLE_EVENTSUBS_MUTEX_UNLOCK(handle);

--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5632,7 +5632,7 @@ rbusError_t rbusEvent_SubscribeExRawData(
                 if(!subInternal)
                 {
                     RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
-                    errorcode = RBUS_ERROR_INVALID_STATE;
+                    errorcode = RBUS_ERROR_INVALID_INPUT;
                 }
                 else
                 {
@@ -5651,7 +5651,7 @@ rbusError_t rbusEvent_SubscribeExRawData(
                 if(!subInternal)
                 {
                     RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
-                    errorcode = RBUS_ERROR_INVALID_STATE;
+                    errorcode = RBUS_ERROR_INVALID_INPUT;
                 }
                 else
                 {


### PR DESCRIPTION
## Fix NULL_RETURNS in rbusEvent_SubscribeExRawData

### Issues Fixed
- **Coverity CID 87:** NULL_RETURNS in `src/rbus/rbus.c` at lines 5644 and 5655

### Root Cause
`rbusEventSubscription_find()` can return NULL, but the returned pointer `subInternal` is dereferenced without NULL checks at:
- Line 5644: `rbusMessage_AddPrivateListener(..., (void *)(subInternal->sub), subInternal->subscriptionId)`
- Line 5655: `rbusMessage_AddListener(..., (void *)(subInternal->sub), subInternal->subscriptionId)`

This can cause a NULL pointer dereference if the subscription lookup fails.

### Changes Made
Added NULL checks before dereferencing `subInternal` in two locations within the `else` block (after successful `rbusEvent_SubscribeWithRetries`):

**Location 1 (myConn path):**
```c
if(!subInternal) {
    RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
    errorcode = RBUS_ERROR_INVALID_INPUT;
}
else {
    memset(rawDataTopic, '\0', strlen(rawDataTopic));
    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", subscription[i].eventName);
    errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, 
                                                (void *)(subInternal->sub), subInternal->subscriptionId);
}
```

**Location 2 (no myConn path):**
```c
if(!subInternal) {
    RBUSLOG_ERROR("%s: subInternal is NULL for event %s", __FUNCTION__, subscription[i].eventName);
    errorcode = RBUS_ERROR_INVALID_INPUT;
}
else {
    snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", subscription[i].eventName);
    errorcode = rbusMessage_AddListener(handle, rawDataTopic, _subscribe_rawdata_handler,
                                        (void *)(subInternal->sub), subInternal->subscriptionId);
}
```

### Pattern Match
This fix follows the exact pattern from **PR #370** (merged by Permanence AI) which fixed the same issue in `rbusEvent_SubscribeRawData`:
- NULL check with else block
- Error logging with function name and event name
- Set `errorcode = RBUS_ERROR_INVALID_INPUT`
- Continue processing (don't break loop)