### PR TITLE
rbus: fixup null returns in getEventTableInstNum

### DIFF
--- a/test/rbus/provider/rbusTestProvider.c
+++ b/test/rbus/provider/rbusTestProvider.c
@@ -1333,7 +1333,14 @@ int getEventTableInstNum(char const* propName)
 {
     int instNum = 0;
     char buff[2] = {0};
-    char const* pinstNum = strstr(propName, "EventsTable.") + 12;
+    char const* pinstNum = strstr(propName, "EventsTable.");
+    
+    if(!pinstNum) {
+        printf("%s: EventsTable not found in %s\n", __FUNCTION__, propName);
+        return 0;  // Return default value
+    }
+    
+    pinstNum += 12;  // Move past "EventsTable."
     buff[0] = *pinstNum;
     instNum = atoi(buff);
     printf("%s %s instNum=%d\n", __FUNCTION__, propName, instNum);


### PR DESCRIPTION
## Fix NULL_RETURNS in getEventTableInstNum

### Issues Fixed
- **Coverity CID 85:** NULL_RETURNS in `test/rbus/provider/rbusTestProvider.c` at line 1337

### Root Cause
`strstr()` can return NULL if the substring "EventsTable." is not found in the input string. The original code adds 12 to the result without checking for NULL, then immediately dereferences it, which can cause a segmentation fault.

### Changes Made
Added NULL check before using the pointer returned by `strstr()`:

**Before:**
```c
char const* pinstNum = strstr(propName, "EventsTable.") + 12;
buff[0] = *pinstNum;  // Crash if strstr returned NULL
```

**After:**
```c
char const* pinstNum = strstr(propName, "EventsTable.");

if(!pinstNum) {
    printf("%s: EventsTable not found in %s\n", __FUNCTION__, propName);
    return 0;  // Return default value
}

pinstNum += 12;  // Move past "EventsTable."
buff[0] = *pinstNum;  // Safe to dereference now
```

- **Line:** 1337