### PR TITLE
rbus: fixup null returns in checkmd5

### DIFF
--- a/test/rbus/consumer/elementTree.c
+++ b/test/rbus/consumer/elementTree.c
@@ -56,6 +56,12 @@ void checkmd5(const char* name, elementNode* root, const char* correctmd5)
     char path[256];
     snprintf(path, 255, "/tmp/%s.txt", name);
     FILE* f = fopen(path, "w");
+    
+    if(!f) {
+        printf("%s: Failed to open file %s\n", __FUNCTION__, path);
+        return;
+    }
+    
     fprintRegisteredElements(f, root, 0);
     fclose(f);
     char md5[MD5_LEN+1];


### PR DESCRIPTION
## Fix NULL_RETURNS in checkmd5

### Issues Fixed
- **Coverity CID 86:** NULL_RETURNS in `test/rbus/elementTree.c` at line 58

### Root Cause
`fopen()` can return NULL if the file cannot be opened (e.g., permission denied, disk full). The original code uses the file pointer without checking for NULL, then attempts to close it, which can cause a segmentation fault.

### Changes Made
Added NULL check before using the file pointer returned by `fopen()`:

**Before:**
```c
FILE* f = fopen(path, "w");
fprintRegisteredElements(f, root, 0);
fclose(f);
```

**After:**
```c
FILE* f = fopen(path, "w");

if(!f) {
    printf("%s: Failed to open file %s\n", __FUNCTION__, path);
    return;
}

fprintRegisteredElements(f, root, 0);
fclose(f);
```

- **Line:** 58