### PR TITLE
rbus: fixup reverse null check in rtMessage_Retain_test1

### DIFF
--- a/unittests/rbus_unit_test_server.cpp
+++ b/unittests/rbus_unit_test_server.cpp
@@ -1308,6 +1308,7 @@ TEST_F(TestServer, rtmsg_rtMessage_SetMessage_test3)
     rtMessage_Release(item);
 }
 
+
 TEST_F(TestServer, rtmsg_rtMessage_Retain_test1)
 {
   rtError err;
@@ -1317,8 +1318,7 @@ TEST_F(TestServer, rtmsg_rtMessage_Retain_test1)
   err = rtMessage_Retain(msg);
   EXPECT_EQ(err, RT_OK);
   rtMessage_Release(msg);
-  if(msg)
-     rtMessage_Release(msg);
+  rtMessage_Release(msg);
 }
 
 TEST_F(TestServer, rtmsg_rtMessage_Clone_test1)


### PR DESCRIPTION
## Fix REVERSE_INULL in rtMessage_Retain_test1

### Issues Fixed
- **Coverity CID 139:** REVERSE_INULL in `unittests/rbus_unit_test_server.cpp` at line 1320

### Root Cause
The code was checking if `msg` is NULL **after** already dereferencing it in `rtMessage_Retain(msg)`. This is a logic error - if `msg` was NULL, the code would crash at line 1317 before reaching the NULL check at line 1320.

### Changes Made
Removed redundant NULL check:

**Before:**
```cpp
rtMessage_Create(&msg);
err = rtMessage_Retain(msg);  // Line 1317: Dereferences msg
EXPECT_EQ(err, RT_OK);
rtMessage_Release(msg);
if(msg)  // Line 1320: Checks NULL (too late!)
   rtMessage_Release(msg);
```

**After:**
```cpp
rtMessage_Create(&msg);
err = rtMessage_Retain(msg);
EXPECT_EQ(err, RT_OK);
rtMessage_Release(msg);
rtMessage_Release(msg);  // No redundant check needed
```

### Why This Fix is Correct
- `rtMessage_Create()` guarantees `msg` is non-NULL
- If `msg` was NULL, the test would fail at `EXPECT_EQ(err, RT_OK)`
- The NULL check at line 1320 was redundant and misleading
- Second `rtMessage_Release()` is intentional (testing double release behavior)