### PR TITLE
rbus: fix NULL pointer dereference in rbusEvent_SubscribeRawData

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -5319,7 +5319,15 @@ rbusError_t  rbusEvent_SubscribeRawData(
         }
         memset(rawDataTopic, '\0', strlen(rawDataTopic));
         snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "%s", eventName);
-        errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+        if(subInternal)
+        {
+            errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+        }
+        else
+        {
+            RBUSLOG_ERROR("%s: subInternal is NULL for %s", __FUNCTION__, eventName);
+            errorcode = RBUS_ERROR_INVALID_INPUT;
+        }
         if(errorcode != RBUS_ERROR_SUCCESS)
         {
             RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);
@@ -5329,8 +5337,16 @@ rbusError_t  rbusEvent_SubscribeRawData(
     {
         subInternal = rbusEventSubscription_find(handleInfo->eventSubs, eventName, NULL, 0, 0, true);
         snprintf(rawDataTopic, RBUS_MAX_NAME_LENGTH, "rawdata.%s", eventName);
-        errorcode = rbusMessage_AddListener(handle, rawDataTopic,
-                _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+        if(subInternal)
+        {
+            errorcode = rbusMessage_AddListener(handle, rawDataTopic,
+                    _subscribe_rawdata_handler, (void *)(subInternal->sub), subInternal->subscriptionId);
+        }
+        else
+        {
+            RBUSLOG_ERROR("%s: subInternal is NULL for %s", __FUNCTION__, eventName);
+            errorcode = RBUS_ERROR_INVALID_INPUT;
+        }
         if(errorcode != RBUS_ERROR_SUCCESS)
         {
             RBUSLOG_ERROR("%s: Listener failed err: %d", __FUNCTION__, errorcode);


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** FORWARD_NULL  
**CWE:** CWE-476 (NULL Pointer Dereference)  
**Severity:** HIGH  
**Function:** `rbusEvent_SubscribeRawData`  
**File:** src/rbus/rbus.c

## Root Cause

The function `rbusEvent_SubscribeRawData` calls `rbusEventSubscription_find()` which can return NULL, but then unconditionally dereferences the returned pointer when accessing `subInternal->sub` and `subInternal->subscriptionId`.

This occurs in two locations:
1. Line 5322 - In the `if(myConn)` branch when calling `rbusMessage_AddPrivateListener()`
2. Line 5340 - In the `else` branch when calling `rbusMessage_AddListener()`

## Changes Made

Added NULL checks before dereferencing `subInternal` in both branches:

### Location 1: if(myConn) branch
```c
if(subInternal)
{
    errorcode = rbusMessage_AddPrivateListener(handle, rawDataTopic, _subscribe_rawdata_handler, 
                                                (void *)(subInternal->sub), subInternal->subscriptionId);
}
else
{
    RBUSLOG_ERROR("%s: subInternal is NULL for %s", __FUNCTION__, eventName);
    errorcode = RBUS_ERROR_INVALID_INPUT;
}
```

### Location 2: else branch
```c
if(subInternal)
{
    errorcode = rbusMessage_AddListener(handle, rawDataTopic,
                                        _subscribe_rawdata_handler, (void *)(subInternal->sub), 
                                        subInternal->subscriptionId);
}
else
{
    RBUSLOG_ERROR("%s: subInternal is NULL for %s", __FUNCTION__, eventName);
    errorcode = RBUS_ERROR_INVALID_INPUT;
}
```

## Why This Fix is Correct

1. **Prevents crash** - NULL pointer dereference would cause segmentation fault
2. **Proper error handling** - Returns `RBUS_ERROR_INVALID_INPUT` when subscription not found
3. **Consistent with codebase** - Other call sites already check for NULL
4. **Maintains functionality** - Only adds safety check, doesn't change logic
5. **Clear error logging** - Logs which event name caused the NULL condition

## Testing

- Verified fix compiles without errors
- Checked that error path is properly handled
- Confirmed both branches (if and else) are fixed
