### PR TITLE
rbus: check return value of remove() in rbus_close

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -17,6 +17,7 @@
  * limitations under the License.
 */
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -3184,7 +3185,11 @@ rbusError_t rbus_close(rbusHandle_t handle)
     LockMutex();
     char filename[RTMSG_HEADER_MAX_TOPIC_LENGTH];
     snprintf(filename, RTMSG_HEADER_MAX_TOPIC_LENGTH-1, "%s%d_%d", "/tmp/.rbus/", getpid(), handleInfo->componentId);
-    remove(filename);
+    int removeRet = remove(filename);
+    if(removeRet != 0 && errno != ENOENT)
+    {
+        RBUSLOG_ERROR("remove(%s) failed with error %d", filename, errno);
+    }
 
     HANDLE_EVENTSUBS_MUTEX_LOCK(handle);
     if(handleInfo->eventSubs)


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** CHECKED_RETURN  
**CWE:** CWE-252 (Unchecked Return Value)  
**Severity:** Medium  
**Function:** `rbus_close`  
**File:** src/rbus/rbus.c

## Root Cause

The function `rbus_close()` calls `remove()` to delete a temporary file (`/tmp/.rbus/<pid>_<componentId>`) but does not check the return value. This could mask failures in file deletion, potentially leading to:
- Accumulated temporary files if deletion consistently fails
- Undetected permission issues
- Disk space issues going unnoticed

## Changes Made

Added return value check for `remove()` with error logging:

```c
int removeRet = remove(filename);
if(removeRet != 0 && errno != ENOENT)
{
    RBUSLOG_ERROR("remove(%s) failed with error %d", filename, errno);
}
```

**Key points:**
- Captures return value in `removeRet`
- Checks if removal failed (`removeRet != 0`)
- Ignores `ENOENT` (file doesn't exist) as this is not an error condition
- Logs actual errors with filename and errno for debugging

Also added `#include <errno.h>` to access errno.

## Why This Fix is Correct

1. **Detects real failures** - Logs when file removal fails for actual errors
2. **Ignores expected cases** - `ENOENT` is not logged (file may not exist)
3. **Aids debugging** - Error message includes filename and errno
4. **No functional change** - Only adds logging, doesn't change behavior
5. **Matches best practices** - Checking system call return values is standard

## Testing

- Verified fix compiles without errors
- Checked that errno is properly included
- Confirmed error logging only triggers on actual failures
