### PR TITLE
rbus: fix NULL pointer dereference in _subscribe_async_callback_handler

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -1364,9 +1364,9 @@ void _subscribe_async_callback_handler(rbusHandle_t handle, rbusEventSubscriptio
 {
     struct _rbusHandle* handleInfo = (struct _rbusHandle*)handle;
 
-    subscription->asyncHandler(subscription->handle, subscription, error);
     if(subscription)
     {
+        subscription->asyncHandler(subscription->handle, subscription, error);
         if(error == RBUS_ERROR_SUCCESS)
         {
             HANDLE_EVENTSUBS_MUTEX_LOCK(handle);
@@ -1388,6 +1388,10 @@ void _subscribe_async_callback_handler(rbusHandle_t handle, rbusEventSubscriptio
         {
             rbusEventSubscription_free(subscription);
         }
+    }
+    else
+    {
+        RBUSLOG_ERROR("Null subscription pointer in _subscribe_async_callback_handler");
     }
 }
 


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** REVERSE_INULL  
**CWE:** CWE-476 (NULL Pointer Dereference)  
**Severity:** High  
**Function:** `_subscribe_async_callback_handler`  
**File:** src/rbus/rbus.c

## Root Cause

The function `_subscribe_async_callback_handler` has a classic REVERSE_INULL defect:
1. Line 1367: Dereferences `subscription->asyncHandler` 
2. Line 1368: Checks if `subscription` is NULL

The NULL check comes **AFTER** the dereference, making it useless. If `subscription` is NULL, the program will crash at line 1367 before reaching the NULL check.

## Changes Made

**Before (Buggy):**
```c
subscription->asyncHandler(subscription->handle, subscription, error);  // ❌ Dereference first
if(subscription)  // ❌ Check second - too late!
{
    // ... rest of code
}
```

**After (Fixed):**
```c
if(subscription)  // ✅ Check first
{
    subscription->asyncHandler(subscription->handle, subscription, error);  // ✅ Dereference second - safe!
    // ... rest of code
}
else
{
    RBUSLOG_ERROR("Null subscription pointer in _subscribe_async_callback_handler");
}
```

## Why This Fix is Correct

1. **Prevents crash** - NULL check happens before dereference
2. **Proper error handling** - Logs error when subscription is NULL
3. **Simple fix** - Just reorder the code, no complex logic
4. **Maintains functionality** - All existing logic preserved, just safer

## Testing

- Verified fix compiles without errors
- Checked that NULL case is properly handled
- Confirmed error logging is in place
