### PR TITLE
rbus: fix unreachable code in rbus_open error handling

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -3017,7 +3017,7 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
     if (rbusHandle_TimeoutValuesInit(tmpHandle) != 0)
     {
         RBUSLOG_ERROR("(%s): rbusHandle_TimeoutValuesInit failed", componentName);
-        goto exit_error2;
+        goto exit_error3;
     }
     tmpHandle->componentName = strdup(componentName);
     tmpHandle->componentId = ++sLastComponentId;
@@ -3045,6 +3045,8 @@ rbusError_t rbus_open(rbusHandle_t* handle, char const* componentName)
 
     RBUSLOG_INFO(" rbus open (%s) success", componentName);
     return RBUS_ERROR_SUCCESS;
+
+exit_error3:
 
     if((err = rbus_unregisterObj(componentName)) != RBUSCORE_SUCCESS)
         RBUSLOG_ERROR("(%s): unregisterObj error %d", componentName, err);


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** UNREACHABLE  
**CWE:** CWE-561 (Dead Code)  
**Severity:** Medium  
**Function:** `rbus_open`  
**File:** src/rbus/rbus.c

## Root Cause

The function `rbus_open` has unreachable code after a return statement:

```c
RBUSLOG_INFO(" rbus open (%s) success", componentName);
return RBUS_ERROR_SUCCESS;

// ❌ UNREACHABLE: This code can never be executed!
if((err = rbus_unregisterObj(componentName)) != RBUSCORE_SUCCESS)
    RBUSLOG_ERROR("(%s): unregisterObj error %d", componentName, err);

exit_error2:
    // ... more cleanup
```

The `rbus_unregisterObj` cleanup code is placed after the return statement, making it impossible to reach. Additionally, when `rbusHandle_TimeoutValuesInit` fails, it does `goto exit_error2`, which skips this cleanup entirely.

## Changes Made

**1. Added new error label `exit_error3`:**
```c
return RBUS_ERROR_SUCCESS;

exit_error3:  // ✅ New label makes code reachable

if((err = rbus_unregisterObj(componentName)) != RBUSCORE_SUCCESS)
    RBUSLOG_ERROR("(%s): unregisterObj error %d", componentName, err);

exit_error2:
```

**2. Changed goto target:**
```c
if (rbusHandle_TimeoutValuesInit(tmpHandle) != 0)
{
    RBUSLOG_ERROR("(%s): rbusHandle_TimeoutValuesInit failed", componentName);
    goto exit_error3;  // ✅ Changed from exit_error2
}
```

## Why This Fix is Correct

1. **Makes code reachable** - The cleanup code can now be executed via goto
2. **Proper error handling** - When TimeoutValuesInit fails, it properly unregisters the object
3. **Maintains cleanup order** - Error labels cascade properly: exit_error3 → exit_error2 → exit_error1 → exit_error0
4. **Simple fix** - Just adds a label and changes one goto target

## Error Handling Flow

**Before (Buggy):**
```
TimeoutValuesInit fails → goto exit_error2 → skips rbus_unregisterObj
```

**After (Fixed):**
```
TimeoutValuesInit fails → goto exit_error3 → calls rbus_unregisterObj → falls through to exit_error2
```

## Testing

- Verified fix compiles without errors
- Checked that error handling flow is correct
- Confirmed cleanup code is now reachable
