### PR TITLE
rtmessage: fix potential divide by zero in rtHashMap_Hash_Func_String

### DIFF
--- a/src/rtmessage/rtHashMap.c
+++ b/src/rtmessage/rtHashMap.c
@@ -295,7 +295,10 @@ uint32_t rtHashMap_Hash_Func_String(rtHashMap hashmap, const void* key)
         hash = hash * 31 + *skey;
         skey++;
     }
-    return abs(hash) % rtVector_Size(hashmap->buckets);
+    size_t buckets_size = rtVector_Size(hashmap->buckets);
+    if(buckets_size == 0)
+        return 0;
+    return abs(hash) % buckets_size;
 }
 
 int rtHashMap_Compare_Func_String(const void* left, const void* right)


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** DIVIDE_BY_ZERO  
**CWE:** CWE-369 (Divide By Zero)  
**Severity:** High  
**Function:** `rtHashMap_Hash_Func_String`  
**File:** src/rtmessage/rtHashMap.c

## Root Cause

The function `rtHashMap_Hash_Func_String` computes a hash value and uses modulo to map it to a bucket:

```c
return abs(hash) % rtVector_Size(hashmap->buckets);
```

If `rtVector_Size(hashmap->buckets)` returns 0 (empty buckets vector), this causes a **divide by zero error**, which will crash the program.

## Changes Made

**Before (Buggy):**
```c
while(*skey)
{
    hash = hash * 31 + *skey;
    skey++;
}
return abs(hash) % rtVector_Size(hashmap->buckets);  // ❌ Can divide by zero!
```

**After (Fixed):**
```c
while(*skey)
{
    hash = hash * 31 + *skey;
    skey++;
}
size_t buckets_size = rtVector_Size(hashmap->buckets);
if(buckets_size == 0)  // ✅ Check for zero
    return 0;
return abs(hash) % buckets_size;  // ✅ Safe to divide
```

## Why This Fix is Correct

1. **Prevents crash** - Checks for zero before division
2. **Reasonable fallback** - Returns 0 when buckets are empty (no valid bucket index exists)
3. **Minimal change** - Just adds a safety check
4. **Performance** - Negligible overhead (one comparison)

## Edge Case Handling

**When does buckets_size == 0?**
- HashMap is newly created but not initialized
- HashMap has been cleared/destroyed
- Corrupted state

**Why return 0?**
- When there are no buckets, there's no valid bucket index
- Returning 0 is a safe default (will be handled by caller)
- Prevents undefined behavior from division by zero

## Testing

- Verified fix compiles without errors
- Checked that zero case is properly handled
- Confirmed normal operation is unaffected
