### PR TITLE
rtmessage: fix NULL pointer dereference in rtRouted_ReadTextFile

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -227,7 +227,10 @@ rtRouted_ReadTextFile(char const* fname, char** content)
       rtLog_Error("failed to read file %s. %s", fname, strerror(errno));
       err = RT_FAIL;
     }
-    (*content)[sz] = 0;
+    else
+    {
+      (*content)[sz] = 0;
+    }
     fclose(pf);
   }
   else


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** FORWARD_NULL  
**CWE:** CWE-476 (NULL Pointer Dereference)  
**Severity:** High  
**Function:** `rtRouted_ReadTextFile`  
**File:** src/rtmessage/rtrouted.c

## Root Cause

The function `rtRouted_ReadTextFile` has a NULL pointer dereference bug:

1. Line 224: `fread(*content, 1, sz, pf)` is called
2. Line 226: If fread fails, `*content` is set to `NULL`
3. Line 230: `(*content)[sz] = 0` is executed **unconditionally**

This means when fread fails, we try to dereference a NULL pointer, causing a crash.

## Changes Made

**Before (Buggy):**
```c
if(fread(*content, 1, sz, pf) != sz)
{
  free(*content);
  *content = NULL;  // Set to NULL on failure
  rtLog_Error("failed to read file %s. %s", fname, strerror(errno));
  err = RT_FAIL;
}
(*content)[sz] = 0;  // ❌ Dereference NULL if fread failed!
fclose(pf);
```

**After (Fixed):**
```c
if(fread(*content, 1, sz, pf) != sz)
{
  free(*content);
  *content = NULL;
  rtLog_Error("failed to read file %s. %s", fname, strerror(errno));
  err = RT_FAIL;
}
else
{
  (*content)[sz] = 0;  // ✅ Only dereference when fread succeeds
}
fclose(pf);
```

## Why This Fix is Correct

1. **Prevents crash** - NULL termination only happens when `*content` is valid
2. **Proper control flow** - Uses else block to ensure mutual exclusivity
3. **Maintains functionality** - Null termination still happens for successful reads
4. **Simple fix** - Just adds an else block, no complex logic

## Error Handling Flow

**Before (Buggy):**
```
fread fails → set *content = NULL → dereference NULL → CRASH
```

**After (Fixed):**
```
fread fails → set *content = NULL → skip null termination → return RT_FAIL (safe)
fread succeeds → null terminate *content → return RT_OK (safe)
```

## Testing

- Verified fix compiles without errors
- Checked that null termination only happens on success
- Confirmed error path doesn't dereference NULL
