### PR TITLE
rbuscli: fix NULL pointer dereference in construct_input_into_cmds

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -2592,11 +2592,18 @@ static int construct_input_into_cmds(char* buff, int* pargc, char** argv)
     int len = (int)strlen(buff);
     int i, j, quote;
     int argc = 0;
-    argv[argc++] = "rbuscli";
+    if (argv)
+    {
+        argv[argc++] = "rbuscli";
+    }
+    else
+    {
+        argc++;
+    }
     runSteps = __LINE__;
     for(i = 0; i < len; ++i)
     {
-        quote = 0;    
+        quote = 0;
         while(i < len && (buff[i] == ' ' || buff[i] == '\t'))
             ++i;
         if(i == len)


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** REVERSE_INULL  
**CWE:** CWE-476 (NULL Pointer Dereference)  
**Severity:** High  
**Function:** `construct_input_into_cmds`  
**File:** utils/rbuscli/rbuscli.c

## Root Cause

The function `construct_input_into_cmds` has a classic REVERSE_INULL defect:

1. Line 2595: Dereferences `argv[argc++] = "rbuscli"`
2. Later in the function: Checks if `argv` is NULL

The dereference happens **BEFORE** any NULL check, making the check useless. If `argv` is NULL, the program will crash at line 2595 before any NULL check can prevent it.

## Changes Made

**Before (Buggy):**
```c
int argc = 0;
argv[argc++] = "rbuscli";  // ❌ Dereference first - crashes if NULL!
runSteps = __LINE__;
// ... later code might check argv for NULL (too late!)
```

**After (Fixed):**
```c
int argc = 0;
if (argv)  // ✅ Check first
{
    argv[argc++] = "rbuscli";  // ✅ Safe to dereference
}
else
{
    argc++;  // ✅ Still increment argc for consistency
}
runSteps = __LINE__;
```

**Also fixed:** Removed trailing whitespace on line with `quote = 0;`

## Why This Fix is Correct

1. **Prevents crash** - NULL check happens before dereference
2. **Maintains consistency** - argc is still incremented even when argv is NULL
3. **Proper error handling** - Function can handle NULL argv gracefully
4. **Simple fix** - Just adds a NULL check, no complex logic

## When Can argv Be NULL?

The function signature is:
```c
static int construct_input_into_cmds(char* buff, int* pargc, char** argv)
```

While uncommon, `argv` could be NULL if:
- Caller passes NULL intentionally to just count arguments
- Memory allocation failure before calling this function
- Programming error in caller

The fix makes the function more robust by handling this edge case.

## Testing

- Verified fix compiles without errors
- Checked that NULL case is properly handled
- Confirmed normal operation (non-NULL argv) is unaffected
