### PR TITLE
rbuscli: fix dead code in hints function

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -2905,7 +2905,7 @@ char *hints(const char *buf, int *color, int *bold) {
             hint = " type(string,int,uint,boolean,...) value";
         }
     }
-    else if(num == 3)
+    else if(num == 4)
     {
         runSteps = __LINE__;
         if(strcmp(tokens[0], "method_va") == 0)


### PR DESCRIPTION
## Issue Fixed

**Coverity Defect:** DEADCODE  
**CWE:** CWE-561 (Dead Code)  
**Severity:** Medium  
**Function:** `hints`  
**File:** utils/rbuscli/rbuscli.c

## Root Cause

The function hints has two else if conditions checking for the same value, making the second one unreachable dead code.

The second else if can never be reached because if num equals 3, the first condition will always catch it first.

## Changes Made

Changed the second condition from num == 3 to num == 4 to make it reachable and handle the 4-token case properly.

## Why This Fix is Correct

1. Removes dead code - The second condition can now be reached when num == 4
2. Logical progression - Conditions now check num == 2, num == 3, num == 4
3. Proper hint handling - Provides hints for 4-token commands
4. Simple fix - Just change 3 to 4

## Testing

- Verified fix compiles without errors
- Checked that the condition sequence is now logical
- Confirmed no other dead code remains
