### PR TITLE
Support Microseconds in RBUS_DATETIME Type

### DIFF
--- a/include/rbus_value.h
+++ b/include/rbus_value.h
@@ -100,6 +100,7 @@ struct tm32
   int32_t tm_wday;			/* Day of week.	[0-6] */
   int32_t tm_yday;			/* Days in year.[0-365]	*/
   int32_t tm_isdst;			/* DST.		[-1/0/1]*/
+  int32_t tm_usec;                      /* microseconds [0-999999] */
 };
 
 typedef struct _rbusDateTime {

--- a/src/rbus/rbus_value.c
+++ b/src/rbus/rbus_value.c
@@ -300,7 +300,7 @@ char* rbusValue_ToString(rbusValue_t v, char* buf, size_t buflen)
             n = snprintf(p, 0, "%.*f", DBL_DIG, v->d.f64)+1;
             break;
         case RBUS_DATETIME:
-            n = snprintf(p, 0, "0000-00-00T00:00:00+00:00") + 1;
+	    	n = snprintf(p, 0, "0000-00-00T00:00:00.000000+00:00") + 1;
             break;
         default:
             n = snprintf(p, 0, "FIXME TYPE %d", v->type)+1;
@@ -373,24 +373,48 @@ char* rbusValue_ToString(rbusValue_t v, char* buf, size_t buflen)
                 snprintf(tmpBuff, 40, "Z");
             }
             if(0 == v->d.tv.m_time.tm_year) {
-                snprintf(p, n, "%04d-%02d-%02dT%02d:%02d:%02d%s", v->d.tv.m_time.tm_year,
+			if(v->d.tv.m_time.tm_usec >= 0)
+			{
+				snprintf(p, n, "%04d-%02d-%02dT%02d:%02d:%02d.%06d%s", v->d.tv.m_time.tm_year,
+                                                                    v->d.tv.m_time.tm_mon,
+                                                                    v->d.tv.m_time.tm_mday,
+                                                                    v->d.tv.m_time.tm_hour,
+                                                                    v->d.tv.m_time.tm_min,
+                                                                    v->d.tv.m_time.tm_sec,
+										v->d.tv.m_time.tm_usec,
+                                                                    tmpBuff);
+			} else {
+                		snprintf(p, n, "%04d-%02d-%02dT%02d:%02d:%02d%s", v->d.tv.m_time.tm_year,
                                                                     v->d.tv.m_time.tm_mon,
                                                                     v->d.tv.m_time.tm_mday,
                                                                     v->d.tv.m_time.tm_hour,
                                                                     v->d.tv.m_time.tm_min,
                                                                     v->d.tv.m_time.tm_sec,
                                                                     tmpBuff);
+			}	
             } else {
                 /* tm_mon represents month from 0 to 11. So increment tm_mon by 1.
                    tm_year represents years since 1900. So add 1900 to tm_year.
                  */
-                snprintf(p, n, "%04d-%02d-%02dT%02d:%02d:%02d%s", v->d.tv.m_time.tm_year+1900,
+		if(v->d.tv.m_time.tm_usec >= 0)
+		{
+                	snprintf(p, n, "%04d-%02d-%02dT%02d:%02d:%02d.%06d%s", v->d.tv.m_time.tm_year+1900,
+                                                                    v->d.tv.m_time.tm_mon+1,
+                                                                    v->d.tv.m_time.tm_mday,
+                                                                    v->d.tv.m_time.tm_hour,
+                                                                    v->d.tv.m_time.tm_min,
+                                                                    v->d.tv.m_time.tm_sec,
+									    	v->d.tv.m_time.tm_usec,
+                                                                    tmpBuff);
+		} else {
+                	snprintf(p, n, "%04d-%02d-%02dT%02d:%02d:%02d%s", v->d.tv.m_time.tm_year+1900,
                                                                     v->d.tv.m_time.tm_mon+1,
                                                                     v->d.tv.m_time.tm_mday,
                                                                     v->d.tv.m_time.tm_hour,
                                                                     v->d.tv.m_time.tm_min,
                                                                     v->d.tv.m_time.tm_sec,
                                                                     tmpBuff);
+		}
             }
             break;
         }
@@ -1226,6 +1250,7 @@ bool rbusValue_SetFromString(rbusValue_t value, rbusValueType_t type, const char
         {
             struct tm tv;
             rbusDateTime_t tvm = {{0},{0}};
+            tvm.m_time.tm_usec = -1;
             if(0 != strncmp(pStringInput,"0000-",5)) {
                 char *pRet = NULL;
                 if(strstr(pStringInput,"T"))
@@ -1237,6 +1262,18 @@ bool rbusValue_SetFromString(rbusValue_t value, rbusValueType_t type, const char
                     return false;
                 }
                 rbusValue_MarshallTMtoRBUS(&tvm, &tv);
+		
+			if (*pRet == '.')
+			{
+				int usec = 0;
+				// Read up to 6 digits after the dot
+				if(sscanf(pRet + 1, "%6d", &usec) == 1)
+					tvm.m_time.tm_usec = usec; // store full microseconds
+			 	pRet++;
+			 	while(*pRet && isdigit((unsigned char)*(pRet)))
+					 pRet++;
+			}	
+
                 if((RBUS_TIMEZONE_LEN == strlen(pRet)) &&
                         (isdigit((int)pRet[1]) &&
                          isdigit((int)pRet[2]) &&
@@ -1247,6 +1284,12 @@ bool rbusValue_SetFromString(rbusValue_t value, rbusValueType_t type, const char
                     sscanf(pRet+1,"%02d:%02d",&(tvm.m_tz.m_tzhour), &(tvm.m_tz.m_tzmin));
                 }
             }
+	    else {
+		    if(strchr(pStringInput,'.'))
+			    tvm.m_time.tm_usec = 0;
+		    else
+			    tvm.m_time.tm_usec = -1;
+	    }
             rbusValue_SetTime(value, &tvm);
         }
         break;


### PR DESCRIPTION
Description: Currently, the RBUS_DATETIME type only supports second-level precision, because it internally uses a struct tm (or tm32) which does not store microseconds.

Components that generate timestamps with microsecond information (e.g., TR-143 DownloadDiagnostics/UploadDiagnostics BOMTime and EOMTime) cannot convey this sub-second data through the standard RBUS APIs.

Added teh changes to support microseconds in rbus_datetime type.