### PR TITLE
RDKB-62907: Remove repetitive logs

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -2501,7 +2501,6 @@ static int _method_callback_handler(rbusHandle_t handle, rbusMessage request, rb
     {
         if(methRegElem->cbTable.methodHandler)
         {
-            RBUSLOG_DEBUG("calling methodHandler method [%s]", methodName);
 
             rbusMethodAsyncHandle_t asyncHandle = rt_malloc(sizeof(struct _rbusMethodAsyncHandle));
             asyncHandle->hdr = *hdr;


### PR DESCRIPTION
Reason for change: Removing repetitive logs
Test Procedure: Build should be successful and check the logs
Risks: Low
Priority: P1
Signed-off-by:Nithishkumar_Thirumoorthi@comcast.com