### PR TITLE
test-devpilot: Fix Coverity defects (1 file)

### DIFF
--- a/sampleapps/provider/rbusTableProvider.c
+++ b/sampleapps/provider/rbusTableProvider.c
@@ -160,7 +160,10 @@ rbusError_t tableAddRowHandler1(rbusHandle_t handle, char const* tableName, char
             t1->instNum = ++gDM.t1InstNum;
             ++g_count;
             if(aliasName)
-                strncpy(t1->alias, aliasName, MAX_LENGTH);
+            {
+                strncpy(t1->alias, aliasName, MAX_LENGTH - 1);
+                t1->alias[MAX_LENGTH - 1] = '\0';
+            }
 
             *instNum = t1->instNum;
             printDataModel();


### PR DESCRIPTION
## Automated Fix for Coverity Defects

**Triggered by:** Sandeep Nair2

### Fixed Files

| File | Line(s) | CIDs | Checker Types | Description |
|------|---------|------|---------------|-------------|
| `sampleapps/provider/rbusTableProvider.c` | L163 | 39973 | BUFFER_SIZE | Buffer not null terminated |

### Fix Summaries

**`sampleapps/provider/rbusTableProvider.c`**

The fix correctly addresses the BUFFER_SIZE 'buffer not null terminated' defect in tableAddRowHandler1 by reducing the strncpy count to MAX_LENGTH-1 and explicitly null-terminating the buffer. The fix is minimal, preserves existing logic, and matches the file's coding style. No new defects are introduced.

