### PR TITLE
devpilot-test: Fix Coverity defects (1 file)

### DIFF
--- a/sampleapps/provider/rbusTableProvider.c
+++ b/sampleapps/provider/rbusTableProvider.c
@@ -396,7 +396,8 @@ rbusError_t setHandler2(rbusHandle_t handle, rbusProperty_t property, rbusSetHan
 
     if(propertyNameEquals(name, "Data"))
     {
-        strncpy(t2->data, rbusValue_GetString(value, NULL), MAX_LENGTH);
+        strncpy(t2->data, rbusValue_GetString(value, NULL), MAX_LENGTH-1);
+        t2->data[MAX_LENGTH-1] = '\0';
         printDataModel();
         return RBUS_ERROR_SUCCESS;
     }


### PR DESCRIPTION
## Automated Fix for Coverity Defects

**Triggered by:** Sandeep Nair2

### Fixed Files

| File | Line(s) | CIDs | Checker Types | Description |
|------|---------|------|---------------|-------------|
| `sampleapps/provider/rbusTableProvider.c` | L399 | 39984 | BUFFER_SIZE | Buffer not null terminated |

### Fix Summaries

**`sampleapps/provider/rbusTableProvider.c`**

The fix correctly addresses the BUFFER_SIZE defect in setHandler2 by reducing the strncpy count to MAX_LENGTH-1 and explicitly null-terminating t2->data[MAX_LENGTH-1]. This is a standard, correct pattern for safe string copying. The fix is minimal, targets only the flagged location, preserves all existing logic, and matches the code style used elsewhere in the file.

